### PR TITLE
Make it work under latest ghc 8.6.4 (and nix)

### DIFF
--- a/src/HttpProxy.hs
+++ b/src/HttpProxy.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Char8     as BC
 import           Control.Monad.Except
 import qualified Data.Conduit.Network.TLS  as N
 import qualified Data.Streaming.Network    as N
-import           System.Timeout
 
 import qualified Data.ByteString.Base64    as B64
 import           Network.Socket            (HostName, PortNumber)

--- a/src/Protocols.hs
+++ b/src/Protocols.hs
@@ -6,8 +6,6 @@ module Protocols where
 import           ClassyPrelude
 import           Control.Concurrent        (forkIO)
 import qualified Data.HashMap.Strict       as H
-import           System.Timeout            (timeout)
-import           System.IO
 
 import qualified Data.ByteString.Char8     as BC
 

--- a/src/Tunnel.hs
+++ b/src/Tunnel.hs
@@ -27,7 +27,6 @@ import qualified Network.WebSockets.Stream     as WS
 import           Control.Monad.Except
 import qualified Network.Connection            as NC
 import           System.IO                     (IOMode (ReadWriteMode))
-import           System.Timeout
 
 import qualified Data.ByteString.Base64        as B64
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -19,8 +19,8 @@ import qualified Network.Socket.ByteString     as N
 
 import qualified Network.WebSockets.Connection as WS
 
-deriving instance Generic PortNumber
-deriving instance Hashable PortNumber
+instance Hashable PortNumber where
+  hashWithSalt s portNumber = hashWithSalt s (toInteger portNumber)
 deriving instance Generic N.SockAddr
 deriving instance Hashable N.SockAddr
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.9
+resolver: lts-13.5
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -35,7 +35,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-extra-deps: [ websockets-0.12.4.1 ]
+extra-deps: [ ]
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Make it work under latest ghc 8.6.4. Usefull in order to make it packagable for nix, as explained [here](https://github.com/erebe/wstunnel/issues/17).