### PR TITLE
Add upgrade authorization

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,6 +31,8 @@ data WsTunnel = WsTunnel
   , verbose         :: Bool
   , quiet           :: Bool
   , pathPrefix      :: String
+  , wsTunnelCredentials
+                    :: String
   } deriving (Show, Data, Typeable)
 
 data WsServerInfo = WsServerInfo
@@ -61,6 +63,10 @@ cmdLine = WsTunnel
   , pathPrefix     = def &= explicit &= name "upgradePathPrefix"
                          &= help "Use a specific prefix that will show up in the http path in the upgrade request. Useful if you need to route requests server side but don't have vhosts"
                          &= typ "String" &= groupname "Client options"
+  , wsTunnelCredentials
+                   = def &= explicit &= name "upgradeCredentials"
+                         &= help "Credentials for the Basic HTTP authorization type sent with the upgrade request."
+                         &= typ "USER[:PASS]"
   , proxy          = def &= explicit &= name "p" &= name "httpProxy"
                          &= help "If set, will use this proxy to connect to the server" &= typ "USER:PASS@HOST:PORT"
   , soMark         = def &= explicit &= name "soMark"
@@ -220,6 +226,7 @@ runApp cfg serverInfo
           , proxySetting = parseProxyInfo (proxy cfg)
           , useSocks = False
           , upgradePrefix = pathPrefix cfg
+          , upgradeCredentials = BC.pack $ wsTunnelCredentials cfg
           , udpTimeout = Main.udpTimeout cfg
       }
 
@@ -236,6 +243,7 @@ runApp cfg serverInfo
           , proxySetting = parseProxyInfo (proxy cfg)
           , useSocks = False
           , upgradePrefix = pathPrefix cfg
+          , upgradeCredentials = BC.pack $ wsTunnelCredentials cfg
           , udpTimeout = Main.udpTimeout cfg
       }
 
@@ -252,6 +260,7 @@ runApp cfg serverInfo
           , proxySetting = parseProxyInfo (proxy cfg)
           , useSocks = False
           , upgradePrefix = pathPrefix cfg
+          , upgradeCredentials = BC.pack $ wsTunnelCredentials cfg
           , udpTimeout = Main.udpTimeout cfg
       }
 
@@ -268,5 +277,6 @@ runApp cfg serverInfo
           , proxySetting = parseProxyInfo (proxy cfg)
           , useSocks = True
           , upgradePrefix = pathPrefix cfg
+          , upgradeCredentials = BC.pack $ wsTunnelCredentials cfg
           , udpTimeout = Main.udpTimeout cfg
       }

--- a/src/Tunnel.hs
+++ b/src/Tunnel.hs
@@ -65,7 +65,8 @@ tunnelingClientP cfg@TunnelSettings{..} app conn = onError $ do
   debug "Oppening Websocket stream"
 
   stream <- connectionToStream conn
-  ret <- WS.runClientWithStream stream serverHost (toPath cfg) WS.defaultConnectionOptions [] run
+  let headers = if not (null upgradeCredentials) then [("Authorization", "Basic " <> B64.encode upgradeCredentials)] else []
+  ret <- WS.runClientWithStream stream serverHost (toPath cfg) WS.defaultConnectionOptions headers run
 
   debug "Closing Websocket stream"
   return ret

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -77,6 +77,8 @@ data TunnelSettings = TunnelSettings
   , useTls        :: Bool
   , useSocks      :: Bool
   , upgradePrefix :: String
+  , upgradeCredentials
+                  :: ByteString
   , udpTimeout    :: Int
   }
 


### PR DESCRIPTION
I'm running `wstunnel` on an public web server, and as the third line of security (after TLS and `upgradePathPrefix`) I'd like to use Basic HTTP authorization because a path prefix is basically a password stored in plaintext. Should I implement reading from file? The credentials can be read by other processes by looking at the command line of a `wstunnel` process.