### PR TITLE
Support network >= 3.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
+        if: github.repository == 'erebe/wstunnel'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -29,7 +30,7 @@ jobs:
         id: docker_build_wstunnel
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ github.repository == 'erebe/wstunnel' && github.ref == 'refs/heads/master' }}
           tags: ghcr.io/erebe/wstunnel:latest
        
           #      - name: extract Artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,23 @@
 # Build Cache image
-FROM alpine:3.12 as builder-cache
-
-RUN apk --no-cache add ca-certificates git ghc curl musl-dev gmp-dev zlib-dev zlib-static pcre-dev xz make upx
-RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64-static.tar.gz | tar xvz && \
-    mv stack*/stack /usr/bin
-
+FROM fpco/stack-build-small:lts-19.2 as builder-cache
 
 COPY stack.yaml /mnt
 COPY *.cabal /mnt
 WORKDIR /mnt
-RUN sed -i 's/lts-16.25/lts-16.4/' stack.yaml && \
-    rm -rf ~/.stack &&  \
+RUN rm -rf ~/.stack &&  \
     stack config set system-ghc --global true && \
     stack setup && \
-    stack install --split-objs --ghc-options="-fPIC" --only-dependencies
+    stack install --ghc-options="-fPIC" --only-dependencies
 
 
 
 # Build phase
-#FROM builder-cache as builder
-FROM ghcr.io/erebe/wstunnel:build-cache as builder
+FROM builder-cache as builder
+# FROM ghcr.io/erebe/wstunnel:build-cache as builder
 COPY . /mnt
 
-RUN sed -i 's/lts-16.25/lts-16.4/' stack.yaml 
 RUN echo '  ld-options: -static' >> wstunnel.cabal ; \
-    stack install --split-objs --ghc-options="-fPIC"
+    stack install --ghc-options="-fPIC"
 #RUN upx /root/.local/bin/wstunnel
 
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -36,7 +36,7 @@ defaultRecvBufferSize = unsafeDupablePerformIO $
   bracket (N.socket N.AF_INET N.Stream 0) N.close (\sock -> N.getSocketOption  sock N.RecvBuffer)
 
 sO_MARK :: N.SocketOption
-sO_MARK = N.CustomSockOpt (1, 36) -- https://elixir.bootlin.com/linux/latest/source/arch/alpha/include/uapi/asm/socket.h#L64
+sO_MARK = N.SockOpt 1 36 -- https://elixir.bootlin.com/linux/latest/source/arch/alpha/include/uapi/asm/socket.h#L64
 
 {-# NOINLINE sO_MARK_Value #-}
 sO_MARK_Value :: IORef Int

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-16.25
+resolver: lts-19.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/wstunnel.cabal
+++ b/wstunnel.cabal
@@ -26,7 +26,7 @@ library
                      , connection
                      , hslogger
                      , mtl
-                     , network 
+                     , network >= 3.1.2
                      , network-conduit-tls
                      , streaming-commons
                      , text >= 1.2.2.1


### PR DESCRIPTION
The `CustomSockOpt` constructor has been removed in network-3.1.2.0 and is now called `SockOpt`.  This PR makes this change, and upgrades the stackage version to 19.2 which includes a sufficiently recent network version.

Probably the biggest change is in the docker container.  I had to change the base because GHC 9.0.2 is not packaged for alpine linux yet.  The fpco/stack-build-small seems to be the small official stackage container (i.e., which is not eleven gigabytes large and contains all of stackage prebuilt).  Unfortunately the GHC from that container doesn't support split objects, so the binary size increases from 6 to 21 megabytes (but it's still statically linked).

The reason why I need to upgrade network is because I am maintaining the nixpkgs package for wstunnel.  We have recently upgraded to GHC 9.0.2 and the new network version, rendering the wstunnel package broken.