### PR TITLE
Allow client certificate CN to be used for upgrade path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ notify = { version = "6.1.1", features = [] }
 
 rustls-native-certs = { version = "0.7.0", features = [] }
 rustls-pemfile = { version = "2.1.1", features = [] }
+x509-parser = "0.16.0"
 scopeguard = "1.2.0"
 serde = { version = "1.0.197", features = ["derive"] }
 socket2 = { version = "0.5.6", features = [] }


### PR DESCRIPTION
Adds the `--http-upgrade-path-use-cert-cn` flag. This causes the wstunnel client to use the common name (CN) of the client's certificate for the upgrade path.

This does not support changing the CN when reloading the certificate. However changing the CN of a client's certificate is un-common when "renewing" (i.e. issuing a new certificate with an extended expiry date) the certificate of a client. Which is the primary use case for the live reload of certificates.