### PR TITLE
When mTLS is used force path to match client certificate CN

### DIFF
--- a/src/tls_utils.rs
+++ b/src/tls_utils.rs
@@ -1,0 +1,27 @@
+use tokio_rustls::rustls::pki_types::CertificateDer;
+use x509_parser::parse_x509_certificate;
+use x509_parser::prelude::X509Certificate;
+
+/// Find a leaf certificate in a vector of certificates. It is assumed only a single leaf certificate
+/// is present in the vector. The other certificates should be (intermediate) CA certificates.
+pub fn find_leaf_certificate<'a>(tls_certificates: &'a Vec<CertificateDer<'static>>) -> Option<X509Certificate<'a>> {
+    for tls_certificate in tls_certificates {
+        if let Ok((_, tls_certificate_x509)) = parse_x509_certificate(tls_certificate) {
+            if !tls_certificate_x509.is_ca() {
+                return Some(tls_certificate_x509);
+            }
+        }
+    }
+    None
+}
+
+/// Returns the common name (CN) as specified in the supplied certificate.
+pub fn cn_from_certificate(tls_certificate_x509: &X509Certificate) -> Option<String> {
+    tls_certificate_x509
+        .tbs_certificate
+        .subject
+        .iter_common_name()
+        .flat_map(|cn| cn.as_str().ok())
+        .map(|cn| cn.to_string())
+        .next()
+}


### PR DESCRIPTION
This change makes the server verify if the client's requested upgrade path prefix matches the common name (CN) in the certificate the client presented when mTLS is used. This makes it impossible for clients to bypass `restrictions.yaml` file when using mTLS.

@erebe I'm not really sure about the best way to "enable" this feature. Currently in this PR it's always enabled when using mTLS. The advantages of this are:
* No additional cli argument needed.
* Secure by default, behavior easy to understand.
  * Which might be what people expect when they define a prefix path in `restrictions.yaml` and use mTLS. It might come as a surprise to users the client can bypass these when using mTLS.

The main disadvantage of not putting this feature behind a cli argument is the `--http-upgrade-path-prefix` argument on the client becomes useless with mTLS since any deviation from the common name won't be accepted by the server (which is kind of the point :wink: ).
 
In #264 we decided it was probably best to allow people to use the `--http-upgrade-path-prefix` flag with mTLS to allow for flexibility. If we want want to support the `--http-upgrade-path-prefix` argument on the client with mTLS and this feature we would probably need a flag on the server. Something like `--restrict-http-upgrade-path-to-client-cn`.

While the flexibility argument in #264 makes sense (there will always be someone who needs it for whatever reason, as [shown in the xkcd comic](https://xkcd.com/1172/)) it does make the behavior of mTLS feature harder to understand for users. It is also not unreasonable to say: "The mTLS support implies security, so it should be secure by default.". In which case we would simply make the `--http-upgrade-path-prefix` illegal to use with mTLS and always check if the upgrade path matches the CN when mTLS is in use. 

Having mTLS (both client and server authenticate to each other) vs. "normal" TLS (only server authenticates to client) is just authentication of the client, it doesn't make anything else more or less secure. Therefor I also think using mTLS with multiple clients having the _same_ client certificate (which is the only use case I can think of for using `--http-upgrade-path-prefix` on the client and also using mTLS) might not really make sense anyway. If you need a single shared secret for all your clients you can just use TLS on the server and HTTP basic auth. 

Let me know what you think! 