### PR TITLE
Mark unsupported configurations as conflicting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,8 @@ struct Client {
 
     /// Use a specific prefix that will show up in the http path during the upgrade request.
     /// Useful if you need to route requests server side but don't have vhosts
+    /// When using mTLS this option overrides the default behavior of using the common name of the
+    /// client's certificate. This will likely result in the wstunnel server rejecting the connection.
     #[arg(
         short = 'P',
         long,
@@ -282,7 +284,12 @@ struct Server {
     /// Server will only accept connection from the specified tunnel information.
     /// Can be specified multiple time
     /// Example: --restrict-to "google.com:443" --restrict-to "localhost:22"
-    #[arg(long, value_name = "DEST:PORT", verbatim_doc_comment)]
+    #[arg(
+        long,
+        value_name = "DEST:PORT",
+        verbatim_doc_comment,
+        conflicts_with = "restrict_config",
+    )]
     restrict_to: Option<Vec<String>>,
 
     /// Server will only accept connection from if this specific path prefix is used during websocket upgrade.
@@ -293,6 +300,7 @@ struct Server {
         short = 'r',
         long,
         verbatim_doc_comment,
+        conflicts_with = "restrict_config",
         env = "WSTUNNEL_RESTRICT_HTTP_UPGRADE_PATH_PREFIX"
     )]
     restrict_http_upgrade_path_prefix: Option<Vec<String>>,


### PR DESCRIPTION
This change marks combining the yaml restrictions file together with arguments such as `--restrict-http-upgrade-path-prefix` as conflicting in clap (the command line argument parser). Since wstunnel will only use the yaml restrictions file when it is supplied and ignore the other arguments. This change makes this more obvious for users (since wstunnel will exit with an error).

The reason for still allowing the client `--http-upgrade-path-prefix` is that one could be using a proxy server in front of wstunnel which does mTLS. This is a pretty specific corner case though. It's a trade-off between flexibility and giving users an option to shoot themselves in the foot. For now a warning was added so it's clear to users that this will only work in specific scenarios.