### PR TITLE
Add option to map (force) port use on the server for reverse tunnels

### DIFF
--- a/restrictions.yaml
+++ b/restrictions.yaml
@@ -48,6 +48,11 @@ restrictions:
           - Unix
         port:
           - 1..65535
+        # Maps ports on the server side from X to Y (X:Y). For example with 10001:8080 configured and a client
+        # which connects using '-R tcp://10001:localhost:80' the server will listen on port 8080 instead of 10001.
+        # The originally requested ports (NOT the mapped ports) need to be allowed via the 'ports' directive.
+        port_mapping:
+          - 10001:8080
         cidr:
           - 0.0.0.0/0
           - ::/0

--- a/src/restrictions/mod.rs
+++ b/src/restrictions/mod.rs
@@ -36,6 +36,7 @@ impl RestrictionsRules {
             let reverse_tunnel = types::AllowConfig::ReverseTunnel(types::AllowReverseTunnelConfig {
                 protocol: vec![],
                 port: vec![],
+                port_mapping: Default::default(),
                 cidr: default_cidr(),
             });
 
@@ -56,6 +57,7 @@ impl RestrictionsRules {
                             types::AllowConfig::ReverseTunnel(types::AllowReverseTunnelConfig {
                                 protocol: vec![],
                                 port: vec![RangeInclusive::new(*port, *port)],
+                                port_mapping: Default::default(),
                                 cidr: vec![IpNet::new(ip, if ip.is_ipv4() { 32 } else { 128 })?],
                             }),
                         ]
@@ -70,6 +72,7 @@ impl RestrictionsRules {
                             types::AllowConfig::ReverseTunnel(types::AllowReverseTunnelConfig {
                                 protocol: vec![],
                                 port: vec![],
+                                port_mapping: Default::default(),
                                 cidr: default_cidr(),
                             }),
                         ]

--- a/src/restrictions/types.rs
+++ b/src/restrictions/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::LocalProtocol;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use regex::Regex;
@@ -56,6 +57,10 @@ pub struct AllowReverseTunnelConfig {
     #[serde(default)]
     pub port: Vec<RangeInclusive<u16>>,
 
+    #[serde(deserialize_with = "deserialize_port_mapping")]
+    #[serde(default)]
+    pub port_mapping: HashMap<u16, u16>,
+
     #[serde(default = "default_cidr")]
     pub cidr: Vec<IpNet>,
 }
@@ -108,6 +113,25 @@ where
         .collect::<Result<Vec<RangeInclusive<u16>>, D::Error>>()?;
 
     Ok(ranges)
+}
+
+fn deserialize_port_mapping<'de, D>(deserializer: D) -> Result<HashMap<u16, u16>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mappings: Vec<String> = Deserialize::deserialize(deserializer)?;
+    mappings
+        .into_iter()
+        .map(|port_mapping| {
+            let port_mapping_parts: Vec<&str> = port_mapping.split(':').collect();
+            if port_mapping_parts.len() != 2 {
+                Err(serde::de::Error::custom(format!("Invalid port_mapping entry: {}", port_mapping)))
+            } else {
+                let orig_port = port_mapping_parts[0].parse::<u16>().map_err(serde::de::Error::custom)?;
+                let target_port = port_mapping_parts[1].parse::<u16>().map_err(serde::de::Error::custom)?;
+                Ok((orig_port, target_port))
+            }
+        }).collect()
 }
 
 fn deserialize_non_empty_vec<'de, D, T>(d: D) -> Result<Vec<T>, D::Error>


### PR DESCRIPTION
This change adds a `port_mapping` option to the `ReverseTunnel` definition in the (YAML) restriction file.

It maps ports on the server side from X to Y (X:Y). Where X is the originally requested port by the client and Y is the port which will be used to listen on server-side.

For example with `10001:8080` configured and a client which connects using `-R tcp://10001:localhost:80` the server will listen on port 8080 instead of 10001. The originally requested ports (NOT the mapped ports) still needs to be allowed via the `ports` directive.

This is for example useful when dealing with lots of clients and you don't want to coordinate port use on all the clients but centrally on the server.

Let me know if this works for you and the project or if you have (other) ideas on it!