### PR TITLE
Fix logging in client mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -742,6 +742,8 @@ async fn main() {
             > 0
         {
             logger.with_writer(io::stderr).init();
+        } else {
+            logger.init()
         }
     } else {
         logger.init();


### PR DESCRIPTION
Because of the changes in 9b82006, logging no longer gets started in client mode (unless it's a stdio tunnel)