### PR TITLE
Restart the WS connection if no pongs are received

### DIFF
--- a/src/tunnel/server.rs
+++ b/src/tunnel/server.rs
@@ -546,11 +546,7 @@ async fn ws_server_upgrade(
     tokio::spawn(
         async move {
             let (ws_rx, mut ws_tx) = match fut.await {
-                Ok(mut ws) => {
-                    ws.set_auto_pong(false);
-                    ws.set_auto_close(false);
-                    ws.split(tokio::io::split)
-                }
+                Ok(ws) => ws.split(tokio::io::split),
                 Err(err) => {
                     error!("Error during http upgrade request: {:?}", err);
                     return;

--- a/src/tunnel/transport/http2.rs
+++ b/src/tunnel/transport/http2.rs
@@ -95,6 +95,10 @@ impl TunnelWrite for Http2TunnelWrite {
     async fn close(&mut self) -> Result<(), io::Error> {
         Ok(())
     }
+
+    async fn handle_message(&mut self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
 }
 
 pub async fn connect(

--- a/src/tunnel/transport/io.rs
+++ b/src/tunnel/transport/io.rs
@@ -65,6 +65,12 @@ pub async fn propagate_local_to_remote(
             warn!("error while writing to tx tunnel {}", err);
             break;
         }
+
+        // Handle outstanding messages
+        if let Err(err) = ws_tx.handle_message().await {
+            warn!("error while dispatching message: {}", err);
+            break;
+        }
     }
 
     // Send normal close

--- a/src/tunnel/transport/mod.rs
+++ b/src/tunnel/transport/mod.rs
@@ -21,6 +21,7 @@ pub trait TunnelWrite: Send + 'static {
     fn write(&mut self) -> impl Future<Output = Result<(), std::io::Error>> + Send;
     fn ping(&mut self) -> impl Future<Output = Result<(), std::io::Error>> + Send;
     fn close(&mut self) -> impl Future<Output = Result<(), std::io::Error>> + Send;
+    fn handle_message(&mut self) -> impl Future<Output = Result<(), std::io::Error>> + Send;
 }
 
 pub trait TunnelRead: Send + 'static {
@@ -75,6 +76,13 @@ impl TunnelWrite for TunnelWriter {
         match self {
             Self::Websocket(s) => s.close().await,
             Self::Http2(s) => s.close().await,
+        }
+    }
+
+    async fn handle_message(&mut self) -> Result<(), std::io::Error> {
+        match self {
+            Self::Websocket(s) => s.handle_message().await,
+            Self::Http2(s) => s.handle_message().await,
         }
     }
 }

--- a/src/tunnel/transport/websocket.rs
+++ b/src/tunnel/transport/websocket.rs
@@ -3,7 +3,7 @@ use crate::tunnel::{tunnel_to_jwt_token, RemoteAddr, JWT_HEADER_PREFIX};
 use crate::WsClientConfig;
 use anyhow::{anyhow, Context};
 use bytes::{Bytes, BytesMut};
-use fastwebsockets::{Frame, OpCode, Payload, WebSocketRead, WebSocketWrite};
+use fastwebsockets::{CloseCode, Frame, OpCode, Payload, WebSocketRead, WebSocketWrite};
 use http_body_util::Empty;
 use hyper::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL, SEC_WEBSOCKET_VERSION, UPGRADE};
 use hyper::header::{CONNECTION, HOST, SEC_WEBSOCKET_KEY};
@@ -186,7 +186,11 @@ impl TunnelWrite for WebsocketTunnelWrite {
     }
 
     async fn close(&mut self) -> Result<(), io::Error> {
-        if let Err(err) = self.inner.write_frame(Frame::close(1000, &[])).await {
+        if let Err(err) = self
+            .inner
+            .write_frame(Frame::close(CloseCode::Normal.into(), &[]))
+            .await
+        {
             return Err(io::Error::new(ErrorKind::BrokenPipe, err));
         }
 

--- a/src/tunnel/transport/websocket.rs
+++ b/src/tunnel/transport/websocket.rs
@@ -4,7 +4,6 @@ use crate::WsClientConfig;
 use anyhow::{anyhow, Context};
 use bytes::{Bytes, BytesMut};
 use fastwebsockets::{Frame, OpCode, Payload, WebSocketRead, WebSocketWrite};
-use futures_util::lock::Mutex;
 use http_body_util::Empty;
 use hyper::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL, SEC_WEBSOCKET_VERSION, UPGRADE};
 use hyper::header::{CONNECTION, HOST, SEC_WEBSOCKET_KEY};
@@ -16,10 +15,19 @@ use hyper_util::rt::TokioIo;
 use std::io;
 use std::io::ErrorKind;
 use std::ops::DerefMut;
-use std::sync::Arc;
 use tokio::io::{AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf};
+use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{debug, trace};
 use uuid::Uuid;
+
+// Messages that can be passed from the reader half to the writer half
+#[derive(Debug)]
+pub enum WebSocketTunnelMessage {
+    Ping(u8),
+    Pong(u8),
+    Close,
+}
 
 #[derive(Debug)]
 pub struct PingState {
@@ -70,20 +78,22 @@ impl PingState {
 }
 
 pub struct WebsocketTunnelWrite {
-    inner: Arc<Mutex<WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>>>,
+    inner: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
     buf: BytesMut,
-    ping_state: Arc<Mutex<PingState>>,
+    ping_state: PingState,
+    receive_from_reader: Receiver<WebSocketTunnelMessage>,
 }
 
 impl WebsocketTunnelWrite {
     pub fn new(
-        ws: Arc<Mutex<WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>>>,
-        ping_state: Arc<Mutex<PingState>>,
+        ws: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
+        receive_from_reader: Receiver<WebSocketTunnelMessage>,
     ) -> Self {
         Self {
             inner: ws,
             buf: BytesMut::with_capacity(MAX_PACKET_LENGTH),
-            ping_state,
+            ping_state: PingState::new(),
+            receive_from_reader,
         }
     }
 }
@@ -99,8 +109,6 @@ impl TunnelWrite for WebsocketTunnelWrite {
 
         let ret = self
             .inner
-            .lock()
-            .await
             .write_frame(Frame::binary(Payload::BorrowedMut(&mut buf[..read_len])))
             .await;
 
@@ -130,22 +138,19 @@ impl TunnelWrite for WebsocketTunnelWrite {
     }
 
     async fn ping(&mut self) -> Result<(), io::Error> {
-        let mut ping_state = self.ping_state.lock().await;
-        debug!("{:?}", *ping_state);
-        if !ping_state.is_ok() {
+        debug!("{:?}", self.ping_state);
+        if !self.ping_state.is_ok() {
             return Err(io::Error::new(ErrorKind::BrokenPipe, "No pong received"));
         }
-        ping_state.ping_inc();
-        debug!("Sending ping({})", ping_state.ping_seq);
+        self.ping_state.ping_inc();
+        debug!("Sending ping({})", self.ping_state.ping_seq);
         if let Err(err) = self
             .inner
-            .lock()
-            .await
             .write_frame(Frame::new(
                 true,
                 OpCode::Ping,
                 None,
-                Payload::BorrowedMut(&mut [ping_state.ping_seq]),
+                Payload::BorrowedMut(&mut [self.ping_state.ping_seq]),
             ))
             .await
         {
@@ -155,8 +160,33 @@ impl TunnelWrite for WebsocketTunnelWrite {
         Ok(())
     }
 
+    async fn handle_message(&mut self) -> Result<(), io::Error> {
+        match self.receive_from_reader.try_recv() {
+            Ok(WebSocketTunnelMessage::Pong(seq)) => {
+                self.ping_state.set_pong_seq(seq);
+                Ok(())
+            }
+            Ok(WebSocketTunnelMessage::Ping(seq)) => {
+                debug!("Sending pong({})", seq);
+                self.inner
+                    .write_frame(Frame::pong(Payload::BorrowedMut(&mut [seq])))
+                    .await
+                    .map_err(|err| io::Error::new(ErrorKind::BrokenPipe, err))
+            }
+            Ok(WebSocketTunnelMessage::Close) => {
+                debug!("Sending close confirmation");
+                self.inner
+                    .write_frame(Frame::close(1000, &[]))
+                    .await
+                    .map_err(|err| io::Error::new(ErrorKind::BrokenPipe, err))
+            }
+            Err(TryRecvError::Empty) => Ok(()),
+            Err(TryRecvError::Disconnected) => Err(io::Error::new(ErrorKind::BrokenPipe, "channel closed")),
+        }
+    }
+
     async fn close(&mut self) -> Result<(), io::Error> {
-        if let Err(err) = self.inner.lock().await.write_frame(Frame::close(1000, &[])).await {
+        if let Err(err) = self.inner.write_frame(Frame::close(1000, &[])).await {
             return Err(io::Error::new(ErrorKind::BrokenPipe, err));
         }
 
@@ -165,56 +195,62 @@ impl TunnelWrite for WebsocketTunnelWrite {
 }
 
 pub struct WebsocketTunnelRead {
-    ws_rx: WebSocketRead<ReadHalf<TokioIo<Upgraded>>>,
-    ws_tx: Arc<Mutex<WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>>>,
-    ping_state: Arc<Mutex<PingState>>,
+    inner: WebSocketRead<ReadHalf<TokioIo<Upgraded>>>,
+    send_to_writer: Sender<WebSocketTunnelMessage>,
 }
 
 impl WebsocketTunnelRead {
     pub const fn new(
-        ws_rx: WebSocketRead<ReadHalf<TokioIo<Upgraded>>>,
-        ws_tx: Arc<Mutex<WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>>>,
-        ping_state: Arc<Mutex<PingState>>,
+        inner: WebSocketRead<ReadHalf<TokioIo<Upgraded>>>,
+        send_to_writer: Sender<WebSocketTunnelMessage>,
     ) -> Self {
-        Self {
-            ws_rx,
-            ws_tx,
-            ping_state,
-        }
+        Self { inner, send_to_writer }
     }
+}
+
+// Since we disable auto_pong and auto_close, we should never end up here.
+// So let's panic so that we don't accidentally end up calling this.
+fn frame_reader(_: Frame<'_>) -> futures_util::future::Ready<anyhow::Result<()>> {
+    unimplemented!()
 }
 
 impl TunnelRead for WebsocketTunnelRead {
     async fn copy(&mut self, mut writer: impl AsyncWrite + Unpin + Send) -> Result<(), io::Error> {
-        loop {
-            let msg = match self
-                .ws_rx
-                .read_frame(&mut |frame| async { self.ws_tx.clone().lock().await.write_frame(frame).await })
-                .await
-            {
-                Ok(msg) => msg,
-                Err(err) => return Err(io::Error::new(ErrorKind::ConnectionAborted, err)),
-            };
+        let msg = match self.inner.read_frame(&mut frame_reader).await {
+            Ok(msg) => msg,
+            Err(err) => return Err(io::Error::new(ErrorKind::ConnectionAborted, err)),
+        };
 
-            trace!("receive ws frame {:?} {:?}", msg.opcode, msg.payload);
-            match msg.opcode {
-                OpCode::Continuation | OpCode::Text | OpCode::Binary => {
-                    return match writer.write_all(msg.payload.as_ref()).await {
-                        Ok(_) => Ok(()),
-                        Err(err) => Err(io::Error::new(ErrorKind::ConnectionAborted, err)),
-                    }
+        trace!("receive ws frame {:?} {:?}", msg.opcode, msg.payload);
+        match msg.opcode {
+            OpCode::Continuation | OpCode::Text | OpCode::Binary => {
+                match writer.write_all(msg.payload.as_ref()).await {
+                    Ok(_) => Ok(()),
+                    Err(err) => Err(io::Error::new(ErrorKind::ConnectionAborted, err)),
                 }
-                OpCode::Close => return Err(io::Error::new(ErrorKind::NotConnected, "websocket close")),
-                // Pings get handled internally, see the closure that we pass to read_frame above
-                OpCode::Ping => continue,
-                OpCode::Pong => {
-                    let seq = msg.payload[0];
-                    debug!("Received pong({})", seq);
-                    let mut ping_state = self.ping_state.lock().await;
-                    ping_state.set_pong_seq(seq);
-                    debug!("{:?}", *ping_state);
-                }
-            };
+            }
+            OpCode::Close => {
+                // Sending back the close confirmation is best effort, if we fail, we just close
+                // the connection anyway
+                _ = self.send_to_writer.send(WebSocketTunnelMessage::Close).await;
+                Err(io::Error::new(ErrorKind::NotConnected, "websocket close"))
+            }
+            OpCode::Ping => {
+                let seq = msg.payload[0];
+                debug!("Received ping({})", seq);
+                self.send_to_writer
+                    .send(WebSocketTunnelMessage::Ping(seq))
+                    .await
+                    .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))
+            }
+            OpCode::Pong => {
+                let seq = msg.payload[0];
+                debug!("Received pong({})", seq);
+                self.send_to_writer
+                    .send(WebSocketTunnelMessage::Pong(seq))
+                    .await
+                    .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))
+            }
         }
     }
 }
@@ -279,14 +315,15 @@ pub async fn connect(
         .with_context(|| format!("failed to do websocket handshake with the server {:?}", client_cfg.remote_addr))?;
 
     ws.set_auto_apply_mask(client_cfg.websocket_mask_frame);
+    ws.set_auto_pong(false);
+    ws.set_auto_close(false);
 
     let (ws_rx, ws_tx) = ws.split(tokio::io::split);
-    let ws_tx = Arc::new(Mutex::new(ws_tx));
-    let ping_state = Arc::new(Mutex::new(PingState::new()));
+    let (ch_tx, ch_rx) = mpsc::channel::<WebSocketTunnelMessage>(32);
 
     Ok((
-        WebsocketTunnelRead::new(ws_rx, ws_tx.clone(), ping_state.clone()),
-        WebsocketTunnelWrite::new(ws_tx, ping_state),
+        WebsocketTunnelRead::new(ws_rx, ch_tx),
+        WebsocketTunnelWrite::new(ws_tx, ch_rx),
         response.into_parts().0,
     ))
 }


### PR DESCRIPTION
With this change, the server will actually respond to ping frames with a corresponding pong frame.
We keep track of the outstanding pings on the client side and we restart the connection if we have more than 3 outstanding pings.

The pongs are sent back automatically by the fastwebsockets library, but to do so, the `WebsocketTunnelRead` struct needs to have access to the `WriteHalf` of the WS connection, in order to send back the pongs. So we now keep the `WriteHalf` in an `Arc<Mutex<_>>`.
The `PingState` that tracks the sent pings and received pongs is also shared between the `WriteHalf` and `ReadHalf`.
