### PR TITLE
Add missing timer to avoid a panic

### DIFF
--- a/src/tunnel/server/server.rs
+++ b/src/tunnel/server/server.rs
@@ -18,7 +18,7 @@ use hyper::body::Incoming;
 use hyper::server::conn::{http1, http2};
 use hyper::service::service_fn;
 use hyper::{http, Request, Response, StatusCode, Version};
-use hyper_util::rt::TokioExecutor;
+use hyper_util::rt::{TokioExecutor, TokioTimer};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use socket2::SockRef;
@@ -436,6 +436,7 @@ impl WsServer {
                                 let websocket_upgrade_fn =
                                     mk_websocket_upgrade_fn(server, restrictions.clone(), restrict_path, peer_addr);
                                 let conn_fut = http1::Builder::new()
+                                    .timer(TokioTimer::new())
                                     .header_read_timeout(Duration::from_secs(10))
                                     .serve_connection(tls_stream, service_fn(websocket_upgrade_fn))
                                     .with_upgrades();


### PR DESCRIPTION
Without this, I get a panic when running the server:

```
vm-test-run-wstunnel> server # [    6.929767] wstunnel-server-my-server-start[618]: thread 'tokio-runtime-worker' panicked at /build/wstunnel-10.0.0-vendor.tar.gz/hyper/src/common/time.rs:73:32:
vm-test-run-wstunnel> server # [    6.933902] wstunnel-server-my-server-start[618]: timeout `header_read_timeout` set, but no timer set
vm-test-run-wstunnel> server # [    6.936716] wstunnel-server-my-server-start[618]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
vm-test-run-wstunnel> server # [    6.970643] systemd-coredump[628]: Process 618 (wstunnel) of user 61212 terminated abnormally with signal 6/ABRT, processing...
vm-test-run-wstunnel> server # [    6.991629] systemd[1]: Created slice Slice /system/systemd-coredump.
vm-test-run-wstunnel> server # [    6.999365] systemd[1]: Started Process Core Dump (PID 628/UID 0).
vm-test-run-wstunnel> server # [    7.293727] systemd-coredump[633]: Process 618 (wstunnel) of user 61212 dumped core.
vm-test-run-wstunnel> server #
vm-test-run-wstunnel> server # Module libgcc_s.so.1 without build-id.
vm-test-run-wstunnel> server # Module wstunnel without build-id.
vm-test-run-wstunnel> server # Stack trace of thread 620:
vm-test-run-wstunnel> server # #0  0x00007f59cee747dc __pthread_kill_implementation (libc.so.6 + 0x927dc)
vm-test-run-wstunnel> server # #1  0x00007f59cee22516 raise (libc.so.6 + 0x40516)
vm-test-run-wstunnel> server # #2  0x00007f59cee0a935 abort (libc.so.6 + 0x28935)
vm-test-run-wstunnel> server # #3  0x00005563583ec3ba _ZN11panic_abort18__rust_start_panic5abort17h273ba75b58bd8eaeE (wstunnel + 0x54b3ba)
vm-test-run-wstunnel> server # #4  0x00005563583ec3a9 __rust_start_panic (wstunnel + 0x54b3a9)
vm-test-run-wstunnel> server # #5  0x000055635858a459 rust_panic (wstunnel + 0x6e9459)
vm-test-run-wstunnel> server # #6  0x0000556358589c3a _ZN3std9panicking20rust_panic_with_hook17h3a41910ac9040dccE (wstunnel + 0x6e8c3a)
vm-test-run-wstunnel> server # #7  0x0000556358596862 _ZN3std9panicking19begin_panic_handler28_$u7b$$u7b$closure$u7d$$u7d$17h4a1c04c4ab6c7070E (wstunnel + 0x6f5862)
vm-test-run-wstunnel> server # #8  0x00005563585967b9 _ZN3std10sys_common9backtrace26__rust_end_short_backtrace17h21d2f857d4d898b1E (wstunnel + 0x6f57b9)
vm-test-run-wstunnel> server # #9  0x00005563585895d6 rust_begin_unwind (wstunnel + 0x6e85d6)
vm-test-run-wstunnel> server # #10 0x0000556357f45a62 _ZN4core9panicking9panic_fmt17hbd29354903ebb815E (wstunnel + 0xa4a62)
vm-test-run-wstunnel> server # #11 0x00005563581d5ff3 _ZN8wstunnel6tunnel6server6server8WsServer5serve28_$u7b$$u7b$closure$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$17h6daa66e75b270f44E (wstunnel + 0x334ff3)
vm-test-run-wstunnel> server # #12 0x000055635816129e _ZN91_$LT$tracing..instrument..Instrumented$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$4poll17hcd43bc17918d71adE (wstunnel + 0x2c029e)
vm-test-run-wstunnel> server # ELF object binary architecture: AMD x86-64
```
