### PR TITLE
Make the ping frequency from the server to the client configurable

### DIFF
--- a/src/tunnel/client/client.rs
+++ b/src/tunnel/client/client.rs
@@ -85,7 +85,7 @@ impl WsClient {
         // Forward local tx to websocket tx
         let ping_frequency = self.config.websocket_ping_frequency;
         tokio::spawn(
-            super::super::transport::io::propagate_local_to_remote(local_rx, ws_tx, close_tx, Some(ping_frequency))
+            super::super::transport::io::propagate_local_to_remote(local_rx, ws_tx, close_tx, ping_frequency)
                 .instrument(Span::current()),
         );
 
@@ -197,13 +197,8 @@ impl WsClient {
             let tunnel = async move {
                 let ping_frequency = client.config.websocket_ping_frequency;
                 tokio::spawn(
-                    super::super::transport::io::propagate_local_to_remote(
-                        local_rx,
-                        ws_tx,
-                        close_tx,
-                        Some(ping_frequency),
-                    )
-                    .in_current_span(),
+                    super::super::transport::io::propagate_local_to_remote(local_rx, ws_tx, close_tx, ping_frequency)
+                        .in_current_span(),
                 );
 
                 // Forward websocket rx to local rx

--- a/src/tunnel/client/config.rs
+++ b/src/tunnel/client/config.rs
@@ -22,7 +22,7 @@ pub struct WsClientConfig {
     pub http_headers_file: Option<PathBuf>,
     pub http_header_host: HeaderValue,
     pub timeout_connect: Duration,
-    pub websocket_ping_frequency: Duration,
+    pub websocket_ping_frequency: Option<Duration>,
     pub websocket_mask_frame: bool,
     pub http_proxy: Option<Url>,
     pub dns_resolver: DnsResolver,

--- a/src/tunnel/server/handler_websocket.rs
+++ b/src/tunnel/server/handler_websocket.rs
@@ -11,7 +11,6 @@ use hyper::header::{HeaderValue, SEC_WEBSOCKET_PROTOCOL};
 use hyper::{Request, Response};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::oneshot;
 use tracing::{error, warn, Instrument, Span};
 
@@ -69,7 +68,7 @@ pub(super) async fn ws_server_upgrade(
                 local_rx,
                 WebsocketTunnelWrite::new(ws_tx, pending_ops),
                 close_tx,
-                Some(Duration::from_secs(30)),
+                server.config.websocket_ping_frequency,
             )
             .await;
         }


### PR DESCRIPTION
Before it was hard-coded to 30 seconds, but this was not clear from the log output which showed the server config as having the ping frequency set to `None`.
With this PR, we align the options for the server and the client, and we add the possibility to disable pings altogether by setting the frequency to zero.
