### PR TITLE
Fix unix domain socket binding for reverse tunnel

### DIFF
--- a/src/protocols/unix_sock/server.rs
+++ b/src/protocols/unix_sock/server.rs
@@ -50,9 +50,14 @@ impl Stream for UnixListenerStream {
 pub async fn run_server(socket_path: &Path) -> Result<UnixListenerStream, anyhow::Error> {
     info!("Starting Unix socket server listening cnx on {:?}", socket_path);
 
-    let path_to_delete = !socket_path.exists();
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)
+            .with_context(|| format!("Failed to delete existing Unix socket at {:?}", socket_path))?;
+    }
+
     let listener = UnixListener::bind(socket_path)
         .with_context(|| format!("Cannot create Unix socket server {:?}", socket_path))?;
+    let path_to_delete = true;
 
     Ok(UnixListenerStream::new(listener, path_to_delete))
 }

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -57,6 +57,12 @@ pub enum LocalProtocol {
     },
 }
 
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub enum BindAddr {
+    Socket(SocketAddr),
+    Unix(String), // Unix socket path
+}
+
 impl LocalProtocol {
     pub const fn is_reverse_tunnel(&self) -> bool {
         matches!(


### PR DESCRIPTION
I case of unix domain socket, local host:port is always 0.0.0.0:0 and when another client wants to connect with a different unix socket path, it binds it to the existing connection.