### PR TITLE
Add hard fileno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdlimit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
+dependencies = [
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3140,7 @@ dependencies = [
  "crossterm",
  "fast-socks5",
  "fastwebsockets",
+ "fdlimit",
  "futures-util",
  "hickory-resolver",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ hickory-resolver = { version = "0.24.1", features = ["tokio", "dns-over-https-ru
 ppp = { version = "2.2.0", features = [] }
 async-channel = { version = "2.3.1", features = [] }
 
+fdlimit = "0.3.0"
+
 # For config file parsing
 regex = { version = "1.11.0", default-features = false, features = ["std", "perf"] }
 serde_regex = "1.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,7 @@ struct Wstunnel {
     /// The soft limit defaults to 1024 on linux for legacy reasons and is not enough for heavy use
     /// of wstunnel proxy features.
     /// The hard limit is significantly higher and will usually suffice.
-    #[arg(
-        long,
-        global = true,
-        verbatim_doc_comment,
-        default_value = "false"
-    )]
+    #[arg(long, global = true, verbatim_doc_comment, default_value = "false")]
     hard_fileno: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,11 +82,10 @@ struct Wstunnel {
     #[arg(
         long,
         global = true,
-        value_name = "HARD_FILENO",
         verbatim_doc_comment,
-        default_value = None
+        default_value = "false"
     )]
-    hard_fileno: Option<String>,
+    hard_fileno: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -741,7 +740,7 @@ async fn main() -> anyhow::Result<()> {
         logger.init();
     };
 
-    if args.hard_fileno.is_some() {
+    if args.hard_fileno {
         fdlimit::raise_fd_limit()?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use base64::Engine;
 use clap::Parser;
 use hyper::header::HOST;
 use hyper::http::{HeaderName, HeaderValue};
-use log::debug;
+use log::{debug, warn};
 use parking_lot::{Mutex, RwLock};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -727,7 +727,9 @@ async fn main() -> anyhow::Result<()> {
     } else {
         logger.init();
     };
-    fdlimit::raise_fd_limit()?;
+    if let Err(err) = fdlimit::raise_fd_limit() {
+        warn!("Failed to set soft filelimit to hard file limit: {}", err)
+    }
 
     match args.commands {
         Commands::Client(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,13 +74,6 @@ struct Wstunnel {
         default_value = "INFO"
     )]
     log_lvl: String,
-
-    /// Increae the fileno soft limit to the fileno hard limit
-    /// The soft limit defaults to 1024 on linux for legacy reasons and is not enough for heavy use
-    /// of wstunnel proxy features.
-    /// The hard limit is significantly higher and will usually suffice.
-    #[arg(long, global = true, verbatim_doc_comment, default_value = "false")]
-    hard_fileno: bool,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -734,10 +727,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         logger.init();
     };
-
-    if args.hard_fileno {
-        fdlimit::raise_fd_limit()?;
-    }
+    fdlimit::raise_fd_limit()?;
 
     match args.commands {
         Commands::Client(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,19 @@ struct Wstunnel {
         default_value = "INFO"
     )]
     log_lvl: String,
+
+    /// Increae the fileno soft limit to the fileno hard limit
+    /// The soft limit defaults to 1024 on linux for legacy reasons and is not enough for heavy use
+    /// of wstunnel proxy features.
+    /// The hard limit is significantly higher and will usually suffice.
+    #[arg(
+        long,
+        global = true,
+        value_name = "HARD_FILENO",
+        verbatim_doc_comment,
+        default_value = None
+    )]
+    hard_fileno: Option<String>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -727,6 +740,10 @@ async fn main() -> anyhow::Result<()> {
     } else {
         logger.init();
     };
+
+    if args.hard_fileno.is_some() {
+        fdlimit::raise_fd_limit()?;
+    }
 
     match args.commands {
         Commands::Client(args) => {


### PR DESCRIPTION
This allows wstunnel to use fds>1024.
Otherwise heavy use can easily run out of file descriptors on connection
attempts.
While there will still be a limit, it is significantly higher (~500
times on my system) which provides enough headroom for connections to be
torn down and fds to be closed.