### PR TITLE
Cleanup validate tunnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3480,7 @@ dependencies = [
  "clap",
  "collection_macros",
  "crossterm",
+ "derive_more",
  "fast-socks5",
  "fastwebsockets",
  "fdlimit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ test-case = "3.3.1"
 collection_macros = "0.2.0"
 rstest = "0.23.0"
 serial_test = "3.2.0"
+derive_more = { version = "1.0.0", features = ["from"] }
 
 [profile.release]
 lto = "fat"

--- a/src/restrictions/types.rs
+++ b/src/restrictions/types.rs
@@ -26,6 +26,7 @@ pub enum MatchConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(test, derive(derive_more::From))]
 pub enum AllowConfig {
     ReverseTunnel(AllowReverseTunnelConfig),
     Tunnel(AllowTunnelConfig),

--- a/src/tunnel/server/server.rs
+++ b/src/tunnel/server/server.rs
@@ -132,11 +132,14 @@ impl WsServer {
         };
 
         let restriction = match validate_tunnel(&remote, path_prefix, &restrictions) {
-            Ok(matched_restriction) => {
+            Some(matched_restriction) => {
                 info!("Tunnel accepted due to matched restriction: {}", matched_restriction.name);
                 matched_restriction
             }
-            Err(_err) => return Err(bad_request()),
+            None => {
+                warn!("Rejecting connection with not allowed destination: {:?}", remote);
+                return Err(bad_request());
+            }
         };
 
         let req_protocol = remote.protocol.clone();

--- a/src/tunnel/server/utils.rs
+++ b/src/tunnel/server/utils.rs
@@ -1,5 +1,6 @@
 use crate::restrictions::types::{
-    AllowConfig, MatchConfig, RestrictionConfig, RestrictionsRules, ReverseTunnelConfigProtocol, TunnelConfigProtocol,
+    AllowConfig, AllowReverseTunnelConfig, AllowTunnelConfig, MatchConfig, RestrictionConfig, RestrictionsRules,
+    ReverseTunnelConfigProtocol, TunnelConfigProtocol,
 };
 use crate::tunnel::transport::{jwt_token_to_tunnel, tunnel_to_jwt_token, JwtTunnelConfig, JWT_HEADER_PREFIX};
 use crate::tunnel::RemoteAddr;
@@ -107,105 +108,96 @@ pub(super) fn extract_tunnel_info(req: &Request<Incoming>) -> Result<TokenData<J
     Ok(jwt)
 }
 
+impl RestrictionConfig {
+    /// Returns true if the path prefix matches the restriction or if the restriction is set to allow any path.
+    #[inline]
+    fn for_path(self: &RestrictionConfig, path_prefix: &str) -> bool {
+        self.r#match.iter().all(|m| match m {
+            MatchConfig::Any => true,
+            MatchConfig::PathPrefix(path) => path.is_match(path_prefix),
+        })
+    }
+}
+
+impl AllowReverseTunnelConfig {
+    #[inline]
+    fn is_allowed(&self, remote: &RemoteAddr) -> bool {
+        if !remote.protocol.is_reverse_tunnel() {
+            return false;
+        }
+
+        if !self.port.is_empty() && !self.port.iter().any(|range| range.contains(&remote.port)) {
+            return false;
+        }
+
+        if !self.protocol.is_empty()
+            && !self
+                .protocol
+                .contains(&ReverseTunnelConfigProtocol::from(&remote.protocol))
+        {
+            return false;
+        }
+
+        match &remote.host {
+            Host::Domain(_) => return false,
+            Host::Ipv4(ip) => self.cidr.iter().any(|cidr| cidr.contains(&IpAddr::from(*ip))),
+            Host::Ipv6(ip) => self.cidr.iter().any(|cidr| cidr.contains(&IpAddr::from(*ip))),
+        }
+    }
+}
+
+impl AllowTunnelConfig {
+    #[inline]
+    fn is_allowed(&self, remote: &RemoteAddr) -> bool {
+        if remote.protocol.is_reverse_tunnel() {
+            return false;
+        }
+
+        if !self.port.is_empty() && !self.port.iter().any(|range| range.contains(&remote.port)) {
+            return false;
+        }
+
+        if !self.protocol.is_empty() && !self.protocol.contains(&TunnelConfigProtocol::from(&remote.protocol)) {
+            return false;
+        }
+
+        match &remote.host {
+            Host::Domain(host) => return self.host.is_match(host),
+            Host::Ipv4(ip) => self.cidr.iter().any(|cidr| cidr.contains(&IpAddr::from(*ip))),
+            Host::Ipv6(ip) => self.cidr.iter().any(|cidr| cidr.contains(&IpAddr::from(*ip))),
+        }
+    }
+}
+
+impl AllowConfig {
+    #[inline]
+    fn is_allowed(&self, remote: &RemoteAddr) -> bool {
+        match self {
+            AllowConfig::ReverseTunnel(config) => config.is_allowed(remote),
+            AllowConfig::Tunnel(config) => config.is_allowed(remote),
+        }
+    }
+}
+
+/// Validate if the requested tunnel is allowed by the restrictions.
+///
+/// Restrictions are checked one by one. If one matches the tunnel, the tunnel will be allowed.
+/// If no restriction matches, the tunnel will be rejected.
+///
+/// # Return value:
+/// * `Some(restriction)` - Tunnel is allowed. Encapsulates the restriction that allowed the tunnel.
+/// * `None` - Tunnel is not allowed.
 #[inline]
 pub(super) fn validate_tunnel<'a>(
     remote: &RemoteAddr,
     path_prefix: &str,
     restrictions: &'a RestrictionsRules,
-) -> Result<&'a RestrictionConfig, ()> {
-    for restriction in &restrictions.restrictions {
-        if !restriction.r#match.iter().all(|m| match m {
-            MatchConfig::Any => true,
-            MatchConfig::PathPrefix(path) => path.is_match(path_prefix),
-        }) {
-            continue;
-        }
-
-        for allow in &restriction.allow {
-            match allow {
-                AllowConfig::ReverseTunnel(allow) => {
-                    if !remote.protocol.is_reverse_tunnel() {
-                        continue;
-                    }
-
-                    if !allow.port.is_empty() && !allow.port.iter().any(|range| range.contains(&remote.port)) {
-                        continue;
-                    }
-
-                    if !allow.protocol.is_empty()
-                        && !allow
-                            .protocol
-                            .contains(&ReverseTunnelConfigProtocol::from(&remote.protocol))
-                    {
-                        continue;
-                    }
-
-                    match &remote.host {
-                        Host::Domain(_) => {}
-                        Host::Ipv4(ip) => {
-                            let ip = IpAddr::V4(*ip);
-                            for cidr in &allow.cidr {
-                                if cidr.contains(&ip) {
-                                    return Ok(restriction);
-                                }
-                            }
-                        }
-                        Host::Ipv6(ip) => {
-                            let ip = IpAddr::V6(*ip);
-                            for cidr in &allow.cidr {
-                                if cidr.contains(&ip) {
-                                    return Ok(restriction);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                AllowConfig::Tunnel(allow) => {
-                    if remote.protocol.is_reverse_tunnel() {
-                        continue;
-                    }
-
-                    if !allow.port.is_empty() && !allow.port.iter().any(|range| range.contains(&remote.port)) {
-                        continue;
-                    }
-
-                    if !allow.protocol.is_empty()
-                        && !allow.protocol.contains(&TunnelConfigProtocol::from(&remote.protocol))
-                    {
-                        continue;
-                    }
-
-                    match &remote.host {
-                        Host::Domain(host) => {
-                            if allow.host.is_match(host) {
-                                return Ok(restriction);
-                            }
-                        }
-                        Host::Ipv4(ip) => {
-                            let ip = IpAddr::V4(*ip);
-                            for cidr in &allow.cidr {
-                                if cidr.contains(&ip) {
-                                    return Ok(restriction);
-                                }
-                            }
-                        }
-                        Host::Ipv6(ip) => {
-                            let ip = IpAddr::V6(*ip);
-                            for cidr in &allow.cidr {
-                                if cidr.contains(&ip) {
-                                    return Ok(restriction);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    warn!("Rejecting connection with not allowed destination: {:?}", remote);
-    Err(())
+) -> Option<&'a RestrictionConfig> {
+    restrictions
+        .restrictions
+        .iter()
+        .filter(|restriction| restriction.for_path(path_prefix))
+        .find(|restriction| restriction.allow.iter().any(|allow| allow.is_allowed(remote)))
 }
 
 pub(super) fn inject_cookie(response: &mut http::Response<impl Body>, remote_addr: &RemoteAddr) -> Result<(), ()> {
@@ -281,14 +273,14 @@ mod tests {
             host: Host::Ipv4([127, 0, 0, 1].into()),
             port: 81,
         };
-        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_err());
+        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_none());
 
         let remote = RemoteAddr {
             protocol: LocalProtocol::Tcp { proxy_protocol: false },
             host: Host::Ipv4([127, 0, 1, 1].into()),
             port: 80,
         };
-        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_err());
+        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_none());
 
         let remote = RemoteAddr {
             protocol: LocalProtocol::Tcp { proxy_protocol: false },
@@ -305,13 +297,202 @@ mod tests {
             host: Host::Domain("not.com".into()),
             port: 80,
         };
-        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_err());
+        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_none());
 
         let remote = RemoteAddr {
             protocol: LocalProtocol::Tcp { proxy_protocol: false },
             host: Host::Ipv6(Ipv6Addr::LOCALHOST),
             port: 80,
         };
-        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_err());
+        assert!(validate_tunnel(&remote, "/doesnt/matter", &restrictions).is_none());
+    }
+
+    #[test]
+    fn test_reverse_tunnel_is_allowed() {
+        let config = AllowReverseTunnelConfig {
+            protocol: vec![ReverseTunnelConfigProtocol::Tcp],
+            port: vec![80..=80],
+            cidr: vec![IpNet::from(Ipv4Net::new([127, 0, 0, 1].into(), 8).unwrap())],
+            port_mapping: Default::default(),
+        };
+
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+        assert!(config.is_allowed(&remote));
+        assert!(AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // another ip on the same subnet
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv4([127, 0, 1, 1].into()),
+            port: 80,
+        };
+        assert!(config.is_allowed(&remote));
+        assert!(AllowConfig::from(config.clone()).is_allowed(&remote));
+    }
+
+    #[test]
+    fn test_reverse_tunnel_is_not_allowed() {
+        let config = AllowReverseTunnelConfig {
+            protocol: vec![ReverseTunnelConfigProtocol::Tcp],
+            port: vec![80..=80],
+            cidr: vec![IpNet::from(Ipv4Net::new([127, 0, 0, 1].into(), 24).unwrap())],
+            port_mapping: Default::default(),
+        };
+
+        // wrong IP
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv4([127, 0, 1, 1].into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // ipv6
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv6(Ipv6Addr::LOCALHOST),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong port
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 81,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong protocol - remote
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseUdp { timeout: None },
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong protocol - local
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+
+        // host is domain
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Domain("example.com".into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+    }
+
+    #[test]
+    fn test_tunnel_is_allowed() {
+        let config = AllowTunnelConfig {
+            protocol: vec![TunnelConfigProtocol::Tcp],
+            port: vec![80..=80],
+            cidr: vec![IpNet::from(Ipv4Net::new([127, 0, 0, 1].into(), 8).unwrap())],
+            host: Regex::new(".*").unwrap(),
+        };
+
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+        assert!(config.is_allowed(&remote));
+        assert!(AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // another ip on the same subnet
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv4([127, 0, 1, 1].into()),
+            port: 80,
+        };
+        assert!(config.is_allowed(&remote));
+        assert!(AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // host is domain
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Domain("example.com".into()),
+            port: 80,
+        };
+        assert!(config.is_allowed(&remote));
+        assert!(AllowConfig::from(config.clone()).is_allowed(&remote));
+    }
+
+    #[test]
+    fn test_tunnel_is_not_allowed() {
+        let config = AllowTunnelConfig {
+            protocol: vec![TunnelConfigProtocol::Tcp],
+            port: vec![80..=80],
+            cidr: vec![IpNet::from(Ipv4Net::new([127, 0, 0, 1].into(), 24).unwrap())],
+            host: Regex::new("example.com").unwrap(),
+        };
+
+        // wrong IP
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv4([127, 0, 1, 1].into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // ipv6
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv6(Ipv6Addr::LOCALHOST),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong port
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 81,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong protocol - remote
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::ReverseTcp,
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong protocol - local
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Udp { timeout: None },
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
+
+        // wrong host
+        let remote = RemoteAddr {
+            protocol: LocalProtocol::Tcp { proxy_protocol: false },
+            host: Host::Domain("not.com".into()),
+            port: 80,
+        };
+        assert!(!config.is_allowed(&remote));
+        assert!(!AllowConfig::from(config.clone()).is_allowed(&remote));
     }
 }


### PR DESCRIPTION
Hi,

This is a suggestion to give a little cleanup to the "validate_tunnel()" function by:
1. Add unitests
2. Use code which (I believe*) is more rust idiomatic and readable to new people looking at the code.

* I understand that the concept of what is idiomatic and what is readable is not absolute and everyone can interpret it differently.
If you'd like these changes and merge them, I can come up with some more.