### PR TITLE
Allow restrictions based on Authorization header

### DIFF
--- a/restrictions.yaml
+++ b/restrictions.yaml
@@ -10,6 +10,9 @@ restrictions:
       # The regex does a match, so if you want to match exactly you need to bound the pattern with ^ $
       # I.e: "tesotron" is going to match "XXXtesotronXXX", but "^tesotron$" is going to match only "tesotron"
       - !PathPrefix "^.*$"
+      # This match applies only if it succeeds to match the Authentication Header with the given regex.
+      # If present, Authentication Header must exists and must match the regex.
+      # - !Authorization "^[Bb]earer +actual_bearer_token_to_match$"
       # The only other possible match type for now is !Any, that match everything/any request
       # - !Any
 

--- a/src/restrictions/types.rs
+++ b/src/restrictions/types.rs
@@ -23,6 +23,8 @@ pub enum MatchConfig {
     Any,
     #[serde(with = "serde_regex")]
     PathPrefix(Regex),
+    #[serde(with = "serde_regex")]
+    Authorization(Regex),
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/tunnel/server/server.rs
+++ b/src/tunnel/server/server.rs
@@ -31,8 +31,8 @@ use crate::tunnel::server::handler_http2::http_server_upgrade;
 use crate::tunnel::server::handler_websocket::ws_server_upgrade;
 use crate::tunnel::server::reverse_tunnel::ReverseTunnelServer;
 use crate::tunnel::server::utils::{
-    HttpResponse, bad_request, extract_path_prefix, extract_tunnel_info, extract_x_forwarded_for, find_mapped_port,
-    validate_tunnel,
+    HttpResponse, bad_request, extract_authorization, extract_path_prefix, extract_tunnel_info,
+    extract_x_forwarded_for, find_mapped_port, validate_tunnel,
 };
 use crate::tunnel::tls_reloader::TlsReloader;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -121,7 +121,9 @@ impl WsServer {
             bad_request()
         })?;
 
-        let restriction = validate_tunnel(&remote, path_prefix, &restrictions).ok_or_else(|| {
+        let authorization = extract_authorization(req);
+
+        let restriction = validate_tunnel(&remote, path_prefix, authorization, &restrictions).ok_or_else(|| {
             warn!("Rejecting connection with not allowed destination: {remote:?}");
             bad_request()
         })?;


### PR DESCRIPTION
Currently, server has only 2 types of restriction matcher: PathPrefix
and Any.

Lets augment the RestrictionConfig to also allow an Authorization Header
matcher; if such matcher is present, the Auth header in the websocket
upgrade request must match the regex set in the matcher.

This provides additional security benefit than using the PathPrefix
matcher in setups where wstunnel server sits behind a load-balancer or
a reverse proxy, where the request's path is logged by such systems.