### PR TITLE
reverse_tunnel: Implement backoff retry upon remote server connection errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,17 @@ pub struct Client {
     ))]
     pub connection_retry_max_backoff: Duration,
 
+    /// The maximum delay between failed reverse tunnel reconnection attempts
+    #[cfg_attr(feature = "clap", arg(
+        long,
+        value_name = "DURATION(s|m|h)",
+        default_value = "1s",
+        value_parser = parsers::parse_duration_sec,
+        alias = "reverse-reconnect-max-delay-sec",
+        verbatim_doc_comment
+    ))]
+    pub reverse_reconnect_max_delay: Duration,
+
     /// Domain name that will be used as SNI during TLS handshake
     /// Warning: If you are behind a CDN (i.e: Cloudflare) you must set this domain also in the http HOST header.
     ///          or it will be flagged as fishy and your request rejected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,13 @@ pub async fn run_client(args: Client) -> anyhow::Result<()> {
         http_proxy,
     };
 
-    let client = WsClient::new(client_config, args.connection_min_idle, args.connection_retry_max_backoff).await?;
+    let client = WsClient::new(
+        client_config,
+        args.connection_min_idle,
+        args.connection_retry_max_backoff,
+        args.reverse_reconnect_max_delay,
+    )
+    .await?;
     info!("Starting wstunnel client v{}", env!("CARGO_PKG_VERSION"),);
 
     // Keep track of all spawned tunnels

--- a/src/test_integrations.rs
+++ b/src/test_integrations.rs
@@ -62,7 +62,9 @@ async fn client_ws(dns_resolver: DnsResolver) -> WsClient {
         http_proxy: None,
     };
 
-    WsClient::new(client_config, 1, Duration::from_secs(1)).await.unwrap()
+    WsClient::new(client_config, 1, Duration::from_secs(1), Duration::from_secs(1))
+        .await
+        .unwrap()
 }
 
 #[fixture]


### PR DESCRIPTION
Currently in reverse-tunnel mode, upon errors when client tries to establish the connection to the remote server, 'run_reverse_tunnel' simply retries every 1s.

This might be too agressive in certain scenarios, for example when the tunnel server (or a load-blancer in front of it) is not yet ready and returns 503. Another example is when the tunnel server does not agree on the tunnel parameters.

Implement an exponential backoff for the delay between reconnect attempts. The maximum reconnect delay is controlled by setting "--reverse-reconnect-max-delay". The default is "1s" in order to keep existing behavior.