### PR TITLE
proof of concept: library returns errors

### DIFF
--- a/src/test_integrations.rs
+++ b/src/test_integrations.rs
@@ -134,7 +134,7 @@ async fn test_tcp_tunnel(
         .await
         .unwrap();
     tokio::spawn(async move {
-        client_ws.run_tunnel(server).await.unwrap();
+        client_ws.run_tunnel(server, None).await.unwrap();
     });
 
     let mut tcp_listener = protocols::tcp::run_server(ENDPOINT_LISTEN.0, false).await.unwrap();
@@ -179,7 +179,7 @@ async fn test_udp_tunnel(
         .await
         .unwrap();
     tokio::spawn(async move {
-        client_ws.run_tunnel(server).await.unwrap();
+        client_ws.run_tunnel(server, None).await.unwrap();
     });
 
     let udp_listener = protocols::udp::run_server(ENDPOINT_LISTEN.0, None, |_| Ok(()), |s| Ok(s.clone()))

--- a/wstunnel-cli/src/main.rs
+++ b/wstunnel-cli/src/main.rs
@@ -94,11 +94,16 @@ async fn main() -> anyhow::Result<()> {
 
     match args.commands {
         Commands::Client(args) => {
-            run_client(*args, DefaultTokioExecutor::default())
+            let results = run_client(*args, DefaultTokioExecutor::default())
                 .await
                 .unwrap_or_else(|err| {
                     panic!("Cannot start wstunnel client: {:?}", err);
                 });
+            for r in results {
+                if let Err(err) = r {
+                    tracing::error!("{err:?}");
+                }
+            }
         }
         Commands::Server(args) => {
             run_server(*args, DefaultTokioExecutor::default())


### PR DESCRIPTION
motivation: #434
    
Proof of concept implementation of a mechanism to send error messages to users of the wstunnel library.
    
Not an optimal API because it uses 3 different mechanisms for error return.
    
The new signature is
    
    pub async fn run_client(args: Client, executor: impl TokioExecutor) -> anyhow::Result<Vec<anyhow::Result<()>>>
    
Errors could be returned in the outer Result, in the inner Result, or in the new error channel added to the LocalToRemote struct.
    
If we maintain it as an external fork we'll likely keep something like this to keep changes minimal.
    
OTOH, we'd be happy to evolve this into something that can be merged.

