### PR TITLE
don't require executor parameter

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -67,3 +67,9 @@ impl TokioExecutor for JoinSetTokioExecutor {
         })
     }
 }
+
+impl Drop for JoinSetTokioExecutor {
+    fn drop(&mut self) {
+        self.abort_all();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use crate::tunnel::server::{TlsServerConfig, WsServer, WsServerConfig};
 use crate::tunnel::transport::{TransportAddr, TransportScheme};
 use crate::tunnel::{RemoteAddr, to_host_port};
 use anyhow::{Context, anyhow};
+use executor::JoinSetTokioExecutor;
 use futures_util::future::BoxFuture;
 use hyper::header::HOST;
 use hyper::http::HeaderValue;
@@ -38,7 +39,8 @@ use tokio::task::JoinSet;
 use tracing::{error, info};
 use url::Url;
 
-pub async fn run_client(args: Client, executor: impl TokioExecutor) -> anyhow::Result<()> {
+pub async fn run_client(args: Client) -> anyhow::Result<()> {
+    let executor = JoinSetTokioExecutor::default();
     let tunnels = create_client_tunnels(args, executor.clone()).await?;
 
     // Start all tunnels

--- a/wstunnel-cli/src/main.rs
+++ b/wstunnel-cli/src/main.rs
@@ -94,11 +94,9 @@ async fn main() -> anyhow::Result<()> {
 
     match args.commands {
         Commands::Client(args) => {
-            run_client(*args, DefaultTokioExecutor::default())
-                .await
-                .unwrap_or_else(|err| {
-                    panic!("Cannot start wstunnel client: {:?}", err);
-                });
+            run_client(*args).await.unwrap_or_else(|err| {
+                panic!("Cannot start wstunnel client: {:?}", err);
+            });
         }
         Commands::Server(args) => {
             run_server(*args, DefaultTokioExecutor::default())


### PR DESCRIPTION
The fix for #433 (socket file leak) added an executor parameter. However, to get the fix, users have to call executor.abort_all(). So the primary motivation for this fix is so that all users get the fix even if they don't call abort_all().

The secondary motivation is to make the API nicer.