### PR TITLE
disable tests using container when on OpenBSD

### DIFF
--- a/wstunnel/src/protocols/tcp/server.rs
+++ b/wstunnel/src/protocols/tcp/server.rs
@@ -225,7 +225,8 @@ pub async fn run_server(bind: SocketAddr, ip_transparent: bool) -> Result<TcpLis
     Ok(TcpListenerStream::new(listener))
 }
 
-#[cfg(test)]
+// there is no docker on OpenBSD
+#[cfg(all(test, not(target_os = "openbsd")))]
 mod tests {
     use super::*;
     use futures_util::pin_mut;


### PR DESCRIPTION
Hi! There is no Docker/Podman on OpenBSD. Thus, the proxy test cannot pass. This patch disables that test on OpenBSD.
