### PR TITLE
ci(release.yml): add linux armv6 architecture

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,10 @@ jobs:
             target: armv7-unknown-linux-musleabihf
             build-args: "--release --no-default-features --features ring"
 
+          - name: Linux armv6
+            target: arm-unknown-linux-musleabihf
+            build-args: "--release --no-default-features --features ring"
+
           - name: Freebsd x86_64
             target: x86_64-unknown-freebsd
             build-args: "--release --no-default-features --features ring --features=jemalloc"


### PR DESCRIPTION
Hello! @erebe

I have modified and verified the workflow!

<img width="1417" alt="wstunnel armv6" src="https://github.com/user-attachments/assets/d92354a5-e9eb-4a5e-8ffd-be9938edf35d" />

Please take a look if it works. Thanks 🙏 

> Related to #447