### PR TITLE
Use unix socket path for server binding

### DIFF
--- a/wstunnel/src/tunnel/server/reverse_tunnel.rs
+++ b/wstunnel/src/tunnel/server/reverse_tunnel.rs
@@ -7,7 +7,6 @@ use futures_util::{StreamExt, pin_mut};
 use log::warn;
 use parking_lot::Mutex;
 use std::future::Future;
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -39,7 +38,7 @@ impl<T: TunnelListener> Drop for ReverseTunnelItem<T> {
 }
 
 pub struct ReverseTunnelServer<T: TunnelListener> {
-    servers: Arc<Mutex<AHashMap<SocketAddr, ReverseTunnelItem<T>>>>,
+    servers: Arc<Mutex<AHashMap<String, ReverseTunnelItem<T>>>>,
 }
 
 impl<T: TunnelListener> ReverseTunnelServer<T> {
@@ -52,7 +51,7 @@ impl<T: TunnelListener> ReverseTunnelServer<T> {
     pub async fn run_listening_server(
         &self,
         executor: &impl TokioExecutorRef,
-        bind_addr: SocketAddr,
+        bind_addr: String,
         idle_timeout: Duration,
         gen_listening_server: impl Future<Output = anyhow::Result<T>>,
     ) -> anyhow::Result<((<T as TunnelListener>::Reader, <T as TunnelListener>::Writer), RemoteAddr)>
@@ -72,7 +71,7 @@ impl<T: TunnelListener> ReverseTunnelServer<T> {
             let nb_seen_clients = Arc::new(AtomicUsize::new(0));
             let seen_clients = nb_seen_clients.clone();
             let server = self.servers.clone();
-            let local_srv2 = bind_addr;
+            let local_srv2 = bind_addr.clone();
 
             let fut = async move {
                 scopeguard::defer!({

--- a/wstunnel/src/tunnel/server/server.rs
+++ b/wstunnel/src/tunnel/server/server.rs
@@ -203,7 +203,7 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                 let ((local_rx, local_tx), remote) = SERVERS
                     .run_listening_server(
                         &self.executor,
-                        bind,
+                        bind.to_string(),
                         self.config.remote_server_idle_timeout,
                         listening_server,
                     )
@@ -222,7 +222,7 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                 let ((local_rx, local_tx), remote) = SERVERS
                     .run_listening_server(
                         &self.executor,
-                        bind,
+                        bind.to_string(),
                         self.config.remote_server_idle_timeout,
                         listening_server,
                     )
@@ -240,7 +240,7 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                 let ((local_rx, local_tx), remote) = SERVERS
                     .run_listening_server(
                         &self.executor,
-                        bind,
+                        bind.to_string(),
                         self.config.remote_server_idle_timeout,
                         listening_server,
                     )
@@ -259,7 +259,7 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                 let ((local_rx, local_tx), remote) = SERVERS
                     .run_listening_server(
                         &self.executor,
-                        bind,
+                        bind.to_string(),
                         self.config.remote_server_idle_timeout,
                         listening_server,
                     )
@@ -275,12 +275,11 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
 
                 let remote_port = find_mapped_port(remote.port, restriction);
                 let local_srv = (remote.host, remote_port);
-                let bind = try_to_sock_addr(local_srv.clone())?;
                 let listening_server = async { UnixTunnelListener::new(path, local_srv, false).await };
                 let ((local_rx, local_tx), remote) = SERVERS
                     .run_listening_server(
                         &self.executor,
-                        bind,
+                        path.to_string_lossy().to_string(),
                         self.config.remote_server_idle_timeout,
                         listening_server,
                     )


### PR DESCRIPTION
Hi,
Currently, when using wstunnel for reverse tunneling of Unix sockets, there's a critical issue where the server creates only one socket file regardless of how many clients connect with different socket addresses. This causes all clients to share the same Unix socket file.

As I'm not a Rust developer, you would probably fix it in a better way. Anyway, I wanted to show you the problem.