### PR TITLE
fix: resolve PROXY protocol v2 parsing errors for mixed IPv4/IPv6 address families

### DIFF
--- a/wstunnel/src/tunnel/server/server.rs
+++ b/wstunnel/src/tunnel/server/server.rs
@@ -185,10 +185,25 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                 };
 
                 if proxy_protocol {
+                    let mut dest_addr = tx.local_addr()?;
+                    
+                    // Fix address family mismatches to satisfy PROXY protocol v2 rules
+                    if client_address.is_ipv6() && dest_addr.is_ipv4() {
+                        dest_addr = std::net::SocketAddr::new(
+                            std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                            dest_addr.port()
+                        );
+                    } else if client_address.is_ipv4() && dest_addr.is_ipv6() {
+                        dest_addr = std::net::SocketAddr::new(
+                            std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                            dest_addr.port()
+                        );
+                    }
+
                     let header = ppp::v2::Builder::with_addresses(
                         ppp::v2::Version::Two | ppp::v2::Command::Proxy,
                         ppp::v2::Protocol::Stream,
-                        (client_address, tx.local_addr()?),
+                        (client_address, dest_addr),
                     )
                     .build()?;
                     let _ = tx.write_all(&header).await;


### PR DESCRIPTION
### Problem

When a client connects to a `wstunnel` server over IPv6 (or provides an IPv6 address via the `X-Forwarded-For` header) but the server targets an IPv4 upstream destination, enabling the proxy protocol (`?proxy_protocol`) results in a malformed header. 

Because `wstunnel` packs these mixed IP addresses without verifying their address families, it violates the PROXY protocol v2 specification, which strictly requires both the source and destination addresses to be of the same family. As a result, the underlying `ppp` crate falls back to an `UNSPEC` family type, breaking strict downstream services like `go-mmproxy` with the following error:

```json
{"level":"debug","ts":1777012619.3955367,"caller":"go-mmproxy/tcp.go:49","msg":"failed to parse PROXY header","listenerNum":0,"protocol":"tcp","listenAdr":"0.0.0.0:20000","remoteAddr":"172.21.0.7:60526","localAddr":"172.17.0.1:20000","error":"failed to parse PROXY v2 header: invalid family/protocol 0/1","dropConnection":true}
```

### Cause

The issue occurs [here](https://github.com/erebe/wstunnel/blob/9d0ec3f27556e3132536401d1b2e4e1aa30c277c/wstunnel/src/tunnel/server/server.rs#L187-L195). When `wstunnel` tries to build the PROXY v2 header, it passes a mixed pair (e.g., IPv6 Source, IPv4 Destination) to the underlying `ppp` crate. The crate cannot build a valid `AF_INET` or `AF_INET6` block from mixed families, so it defaults to `UNSPEC` (0) with protocol `STREAM` (1), resulting in downstream parsing error.

### Solution

There are a few ways to approach this:
1. Simply return an error to the client if a mismatch is found.
2. Require users to configure an IPv6 destination if they expect IPv6 clients. 
3. **Replace the destination IP with a dummy IP of the matching family.**

We opted to implement the third solution. If a mismatch is detected, this PR replaces the internal destination IP with an `UNSPECIFIED` dummy IP (`::` or `0.0.0.0`) of the same family as the client IP. 

While this technically masks the true internal destination IP in the proxy header, downstream services (like `go-mmproxy` used for IP spoofing) typically only care about the Source IP. This approach safely satisfies the PROXY protocol spec and allows seamless bridging of IPv6 clients to IPv4-only internal setups without breaking connections.

### Testing

I have implemented this solution and conducted testing in a real-world edge environment. I built a Docker image using this [updated Dockerfile](https://github.com/tianq02/wstunnel/blob/68644cf46cf95e319079cbb17f3c719ec4cfb77f/Dockerfile) and published it to `ccr.ccs.tencentyun.com/tianq/wstunnel:v10.5.2.fix`. This image is currently deployed on my server behind a CDN, and I can confirm it works exactly as intended, fully resolving the `go-mmproxy` drops.