### PR TITLE
fix: disable IPv6OrigDstAddr setsockopt on uclibc target env

### DIFF
--- a/wstunnel/src/protocols/udp/server.rs
+++ b/wstunnel/src/protocols/udp/server.rs
@@ -440,6 +440,7 @@ pub fn configure_tproxy(listener: &UdpSocket) -> anyhow::Result<()> {
             nix::sys::socket::setsockopt(&listener.as_fd(), nix::sys::socket::sockopt::Ipv4OrigDstAddr, &true)?;
         }
         IpAddr::V6(_) => {
+            #[cfg(not(target_env = "uclibc"))]
             nix::sys::socket::setsockopt(&listener.as_fd(), nix::sys::socket::sockopt::Ipv6OrigDstAddr, &true)?;
         }
     };


### PR DESCRIPTION
- The Issue
When compiling wstunnel for a uclibc target environment (frequently used in embedded systems and routers), compilation fails because `nix::sys::socket::sockopt::Ipv6OrigDstAddr` is unresolved.

- The Cause
In the nix crate, the `Ipv6OrigDstAddr` socket option struct is conditionally compiled out on uClibc environments. In nix's source code, `Ipv6OrigDstAddr` is gated as follows:
```rust
#[cfg(any(
    all(linux_android, not(target_env = "uclibc")),
    target_os = "freebsd"
))]
#[cfg(feature = "net")]
sockopt_impl!(
    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
    /// The `recvmsg(2)` call will return the destination IP address for a UDP
    /// datagram.
    Ipv6OrigDstAddr,
    Both,
    libc::IPPROTO_IPV6,
    libc::IPV6_ORIGDSTADDR,
    bool
);
```

This gate exists because uClibc often lacks the corresponding standard C library headers and definition constants (such as `IPV6_ORIGDSTADDR`) required to support transparent IPv6 destination retrieval over UDP.

The Implementation
To allow the project to compile successfully on uClibc target environments, I added a matching conditional compilation guard 
`#[cfg(not(target_env = "uclibc"))]` in `server.rs`:
```rust
        IpAddr::V6(_) => {
            #[cfg(not(target_env = "uclibc"))]
            nix::sys::socket::setsockopt(&listener.as_fd(), nix::sys::socket::sockopt::Ipv6OrigDstAddr, &true)?;
        }
```
This conditionally compiles out the call to `nix::sys::socket::setsockopt` using `Ipv6OrigDstAddr` only when building for uclibc target environments, preventing compilation errors.
