### PR TITLE
feat: Cache and hot-reload system CA certificates with thread-safe CryptoProvider initialization

### DIFF
--- a/wstunnel-cli/src/main.rs
+++ b/wstunnel-cli/src/main.rs
@@ -8,6 +8,7 @@ use wstunnel::LocalProtocol;
 use wstunnel::config::{Client, Server};
 use wstunnel::executor::DefaultTokioExecutor;
 use wstunnel::{run_client, run_server};
+use wstunnel::tunnel::ca_reloader::SystemCaReloader;
 
 #[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;
@@ -91,6 +92,9 @@ async fn main() -> anyhow::Result<()> {
     if let Err(err) = fdlimit::raise_fd_limit() {
         warn!("Failed to set soft filelimit to hard file limit: {}", err)
     }
+
+    // Start system CA reloader
+    let _ = SystemCaReloader::start(None);
 
     match args.commands {
         Commands::Client(args) => {

--- a/wstunnel/src/protocols/dns/resolver.rs
+++ b/wstunnel/src/protocols/dns/resolver.rs
@@ -20,7 +20,7 @@ use hickory_resolver::net::NetError;
 use tokio_rustls::rustls;
 #[cfg(feature = "aws-lc-rs")]
 use tokio_rustls::rustls::client::EchConfig;
-use tokio_rustls::rustls::{ClientConfig, RootCertStore};
+use tokio_rustls::rustls::ClientConfig;
 
 // Interleave v4 and v6 addresses as per RFC8305.
 // The first address is v6 if we have any v6 addresses.
@@ -231,27 +231,15 @@ impl DnsResolver {
 }
 
 fn tls_client_config() -> Result<ClientConfig, rustls::Error> {
-    let mut root_store = RootCertStore::empty();
-
-    // Load system certificates and add them to the root store
-    let certs = rustls_native_certs::load_native_certs();
-    certs.errors.iter().for_each(|err| {
-        warn!("cannot load system some system certificates: {err}");
-    });
-    for cert in certs.certs {
-        if let Err(err) = root_store.add(cert) {
-            warn!("cannot load a system certificate: {err:?}");
-            continue;
-        }
-    }
+    // Load system certificates
+    let root_store = crate::tunnel::ca_reloader::get_root_store();
 
     if root_store.is_empty() {
         warn!(
             "DNS resolver has loaded no system certificates. If you use Dns Over HTTPS, or tls-over-https, it is most likely going to fail. Please install system certificates to avoid this warning."
         );
     }
-    let config_builder = ClientConfig::builder_with_provider(ClientConfig::builder().crypto_provider().clone())
-        .with_safe_default_protocol_versions()?
+    let config_builder = ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     Ok(config_builder)

--- a/wstunnel/src/protocols/tls/server.rs
+++ b/wstunnel/src/protocols/tls/server.rs
@@ -111,21 +111,10 @@ pub fn tls_connector(
     tls_client_certificate: Option<Vec<CertificateDer<'static>>>,
     tls_client_key: Option<PrivateKeyDer<'static>>,
 ) -> anyhow::Result<TlsConnector> {
-    let mut root_store = RootCertStore::empty();
+    // Load system certificates
+    let root_store = crate::tunnel::ca_reloader::get_root_store();
+	let crypto_provider = rustls::crypto::CryptoProvider::get_default().unwrap().clone();
 
-    // Load system certificates and add them to the root store
-    let certs = rustls_native_certs::load_native_certs();
-    certs.errors.iter().for_each(|err| {
-        warn!("cannot load system some system certificates: {err}");
-    });
-    for cert in certs.certs {
-        if let Err(err) = root_store.add(cert) {
-            warn!("cannot load a system certificate: {err:?}");
-            continue;
-        }
-    }
-
-    let crypto_provider = ClientConfig::builder().crypto_provider().clone();
     let config_builder = ClientConfig::builder_with_provider(crypto_provider);
     let config_builder = if let Some(ech_config) = ech_config {
         info!("Using TLS ECH (encrypted sni) with config: {:?}", ech_config);

--- a/wstunnel/src/tunnel/ca_reloader.rs
+++ b/wstunnel/src/tunnel/ca_reloader.rs
@@ -1,0 +1,80 @@
+use arc_swap::ArcSwap;
+use std::sync::{Arc, LazyLock, Once};
+use std::time::Duration;
+use tokio_rustls::rustls::RootCertStore;
+use tracing::{debug, warn};
+
+// Global thread-safe store for system CA certificates
+static SYSTEM_ROOT_STORE: LazyLock<ArcSwap<RootCertStore>> = LazyLock::new(|| {
+    SystemCaReloader::init_crypto_provider();
+    ArcSwap::from_pointee(SystemCaReloader::load_system_ca_certs())
+});
+
+/// Get the global system root store
+pub fn get_root_store() -> Arc<RootCertStore> {
+    SYSTEM_ROOT_STORE.load().clone()
+}
+
+pub struct SystemCaReloader;
+
+impl SystemCaReloader {
+    /// Spawn a background task to periodically reload system CA certificates
+    pub fn start(interval: Option<Duration>) -> tokio::task::JoinHandle<()> {
+        let interval = interval.unwrap_or(Duration::from_secs(3600));
+        let _ = get_root_store();
+
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // Skip first tick as it is loaded by LazyLock on first use
+            ticker.tick().await;
+
+            loop {
+                ticker.tick().await;
+                let new_store = Self::load_system_ca_certs();
+                if !new_store.is_empty() {
+                    SYSTEM_ROOT_STORE.store(Arc::new(new_store));
+                    debug!("System CA certificates reloaded successfully");
+                } else {
+                    warn!("Reloaded system CA certificates store was empty, ignoring replacement");
+                }
+            }
+        })
+    }
+
+    /// Safely initializes the process-wide default CryptoProvider exactly once
+    fn init_crypto_provider() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            #[cfg(feature = "aws-lc-rs")]
+            {
+                if tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
+                    .install_default()
+                    .is_err()
+                {
+                    #[cfg(feature = "ring")]
+                    let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+                }
+            }
+            #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+            {
+                let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+            }
+        });
+    }
+
+    /// Helper function to load system certificates into a RootCertStore
+    fn load_system_ca_certs() -> RootCertStore {
+        let mut root_store = RootCertStore::empty();
+        let certs = rustls_native_certs::load_native_certs();
+        certs.errors.iter().for_each(|err| {
+            warn!("cannot load system some system certificates: {err}");
+        });
+        for cert in certs.certs {
+            if let Err(err) = root_store.add(cert) {
+                warn!("cannot load a system certificate: {err:?}");
+                continue;
+            }
+        }
+        root_store
+    }
+}

--- a/wstunnel/src/tunnel/mod.rs
+++ b/wstunnel/src/tunnel/mod.rs
@@ -1,3 +1,4 @@
+pub mod ca_reloader;
 pub mod client;
 pub mod connectors;
 pub mod listeners;


### PR DESCRIPTION
Currently, `wstunnel` loads system CA certificates synchronously from the operating system (registry/files/keychain) every single time a new TLS client connector is built or a DoH (DNS-over-HTTPS) query configuration is initialized. This incurs substantial I/O overhead (e.g., registry queries on Windows or disk reads on Linux) and duplicate certificate parsing on every connection attempt.

This PR introduces a thread-safe, cached system certificate store (`SYSTEM_ROOT_STORE`) utilizing `arc_swap` and `LazyLock`. It also adds a background worker (`SystemCaReloader`) to periodically reload and swap system certificates in the background, making subsequent connections extremely lightweight and resilient to OS-level certificate updates.

Additionally, this PR encapsulates process-wide `rustls` `CryptoProvider` installation into a single idempotent `Once` block, preventing potential panic or double-installation errors.

## Key Changes

1.  **System CA Caching (`SYSTEM_ROOT_STORE`)**:
    
    *   Replaced synchronous `rustls_native_certs::load_native_certs()` invocations on every connection with a global, thread-safe cache (`SYSTEM_ROOT_STORE`) wrapped in `std::sync::LazyLock` and `arc_swap::ArcSwap`.
    *   Accessing the root store is now lock-free and extremely cheap.
2.  **Periodic Background Reloading (`SystemCaReloader`)**:
    
    *   Added a `SystemCaReloader` helper struct.
    *   Spawns a lightweight background task to periodically reload and hot-swap system CAs (defaulting to once every hour) to capture any newly installed certificates on the OS without interrupting running tunnels.
    *   Incorporates a safety check: if the OS returns an empty certificate store during reload, the update is ignored to prevent overwriting active certs with empty data.
3.  **Robust `CryptoProvider` Initialization**:
    
    *   Moves `rustls` default crypto provider registration into a thread-safe `Once` initialization block within the root store initializer.
    *   Safely registers `aws-lc-rs` (if enabled) with a fallback to `ring` (if enabled) without double-installation crashes.
4.  **Integration with CLI Entrypoint**:
    
    *   Spawns the `SystemCaReloader` background task inside `wstunnel-cli`'s `main` entrypoint, keeping the core library's `run_client` and `run_server` clean and free of unsolicited background thread spawns.

## Benefits

*   **Performance**: Drastically reduces TLS handshake latency and resource overhead by avoiding disk/registry reads and certificate parsing for each connection.
*   **Reliability**: Long-running CLI processes automatically pick up system-wide CA updates without requiring a service restart.
*   **Robustness**: Prevents duplicate provider registration crashes when using `wstunnel` in multi-threaded environments.