### PR TITLE
fix(socks5): bound inbound handshake with a timeout

### DIFF
--- a/wstunnel/src/protocols/socks5/tcp_server.rs
+++ b/wstunnel/src/protocols/socks5/tcp_server.rs
@@ -18,6 +18,11 @@ use tokio::task::JoinSet;
 use tracing::{info, warn};
 use url::Host;
 
+/// Max time a client has to send its SOCKS5 greeting and command once connected.
+/// The accept loop handles connections one at a time, so an idle client must not
+/// hold it: a real client sends its handshake immediately.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 #[allow(clippy::type_complexity)]
 pub struct Socks5Listener {
     socks_server: Pin<Box<dyn Stream<Item = anyhow::Result<(Socks5Stream, (Host, u16))>> + Send>>,
@@ -114,39 +119,56 @@ pub async fn run_server(
                     }
                 };
 
-                // Authenticate the connection
+                // Authenticate the connection, bounding the handshake read so a
+                // silent client cannot hold the accept loop (see HANDSHAKE_TIMEOUT).
                 let proto = if let Some((ref username, ref password)) = credentials {
                     let username = username.clone();
                     let password = password.clone();
-                    match Socks5ServerProtocol::accept_password_auth(socket, move |user, pass| {
-                        user == username && pass == password
-                    })
+                    match tokio::time::timeout(
+                        HANDSHAKE_TIMEOUT,
+                        Socks5ServerProtocol::accept_password_auth(socket, move |user, pass| {
+                            user == username && pass == password
+                        }),
+                    )
                     .await
                     {
-                        Ok((proto, _)) => proto,
-                        Err(err) => {
+                        Ok(Ok((proto, _))) => proto,
+                        Ok(Err(err)) => {
                             warn!("Rejecting socks5 cnx (auth failed): {}", err);
+                            continue;
+                        }
+                        Err(_) => {
+                            warn!("Rejecting socks5 cnx: handshake timed out after {:?}", HANDSHAKE_TIMEOUT);
                             continue;
                         }
                     }
                 } else {
-                    match Socks5ServerProtocol::accept_no_auth(socket).await {
-                        Ok(proto) => proto,
-                        Err(err) => {
+                    match tokio::time::timeout(HANDSHAKE_TIMEOUT, Socks5ServerProtocol::accept_no_auth(socket)).await {
+                        Ok(Ok(proto)) => proto,
+                        Ok(Err(err)) => {
                             warn!("Rejecting socks5 cnx (auth failed): {}", err);
+                            continue;
+                        }
+                        Err(_) => {
+                            warn!("Rejecting socks5 cnx: handshake timed out after {:?}", HANDSHAKE_TIMEOUT);
                             continue;
                         }
                     }
                 };
 
-                // Read the SOCKS5 command
-                let (proto, cmd, target_addr) = match proto.read_command().await {
-                    Ok(result) => result,
-                    Err(err) => {
-                        warn!("Rejecting socks5 cnx: {}", err);
-                        continue;
-                    }
-                };
+                // Read the SOCKS5 command, bounded by the same handshake timeout.
+                let (proto, cmd, target_addr) =
+                    match tokio::time::timeout(HANDSHAKE_TIMEOUT, proto.read_command()).await {
+                        Ok(Ok(result)) => result,
+                        Ok(Err(err)) => {
+                            warn!("Rejecting socks5 cnx: {}", err);
+                            continue;
+                        }
+                        Err(_) => {
+                            warn!("Rejecting socks5 cnx: command read timed out after {:?}", HANDSHAKE_TIMEOUT);
+                            continue;
+                        }
+                    };
 
                 let (host, port) = match &target_addr {
                     TargetAddr::Ip(SocketAddr::V4(ip)) => (Host::Ipv4(*ip.ip()), ip.port()),


### PR DESCRIPTION
## Problem

The SOCKS5 server's accept loop (`protocols/socks5/tcp_server.rs`) handles
connections serially and awaits `accept_no_auth` / `accept_password_auth` /
`read_command` with no timeout. A client that completes the TCP connection but
never sends its SOCKS5 greeting/command blocks the loop, so no further
connection to the port is serviced until the process restarts. The port stays
bound, so a plain TCP health check still reports it healthy.

This also matches the symptom in #485 ("unable to accept any additional
connections to the socks port").

## Fix

Wrap the three handshake reads in a 10s `tokio::time::timeout`. On timeout the
connection is dropped and the loop continues accepting. A well-behaved client
sends its handshake immediately, so the bound does not affect normal use.

## Reproduce

```
# terminal 1 — server
wstunnel server ws://127.0.0.1:8080
# terminal 2 — reverse socks5 tunnel
wstunnel client -R socks5://127.0.0.1:1080 ws://127.0.0.1:8080
# terminal 3
curl -x socks5h://127.0.0.1:1080 http://example.com    # works
nc 127.0.0.1 1080 &                                     # half-open, sends nothing
curl -x socks5h://127.0.0.1:1080 http://example.com    # before: hangs until restart
```

With the fix, the listener resumes serving once the stalled handshake times out.

## Notes

- Scope is the inbound SOCKS5 handshake on the listener; unrelated to the
  reverse-tunnel websocket handshake wait.
- Could be exposed as a CLI flag if you'd prefer it configurable - happy to
  adjust.
