### PR TITLE
fix(client): bound the TLS handshake with a timeout

### DIFF
--- a/wstunnel/src/tunnel/client/cnx_pool.rs
+++ b/wstunnel/src/tunnel/client/cnx_pool.rs
@@ -2,11 +2,12 @@ use crate::protocols;
 use crate::protocols::tls;
 use crate::tunnel::client::WsClientConfig;
 use crate::tunnel::client::l4_transport_stream::TransportStream;
+use anyhow::anyhow;
 use bb8::ManageConnection;
 use bytes::Bytes;
 use std::ops::Deref;
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 #[derive(Clone)]
 pub struct WsConnection(Arc<WsClientConfig>);
@@ -55,7 +56,16 @@ impl ManageConnection for WsConnection {
         };
 
         if self.remote_addr.tls().is_some() {
-            let tls_stream = tls::connect(self, tcp_stream).await?;
+            // Bound the TLS handshake with the same timeout as the TCP connect,
+            // so a peer that accepts the connection but never completes the
+            // handshake is dropped instead of held.
+            let tls_stream = match tokio::time::timeout(timeout, tls::connect(self, tcp_stream)).await {
+                Ok(res) => res?,
+                Err(_) => {
+                    warn!("Timed out after {timeout:?} doing the TLS handshake with the server");
+                    return Err(anyhow!("Timed out doing the TLS handshake with the server"));
+                }
+            };
             Ok(Some(TransportStream::from_client_tls(tls_stream, Bytes::default())))
         } else {
             Ok(Some(TransportStream::from_tcp(tcp_stream, Bytes::default())))


### PR DESCRIPTION
## Problem

In the client connection pool (`tunnel/client/cnx_pool.rs`), `connect()`
time-limits the TCP connect but the subsequent TLS handshake
(`tls::connect` → `tls_connector.connect().await`) has no timeout.

If a server accepts the TCP connection but never completes the TLS
handshake (e.g. a load balancer that holds the connection open while its
backend is down), the handshake future never returns.

Because the pool (bb8) counts that attempt as a connection that is still
being established, it won't start a new one in its place — so every
`get()` waits for a connection that never arrives and fails with:

`failed to get a connection to the server from the pool: TimedOut`

The client never recovers on its own — not even after the server becomes
reachable again or is restarted, since the dead connection terminates at
the intermediary and is never reset. Only restarting the client clears it.

## Fix

Wrap the TLS handshake in the same `timeout` already used for the TCP
connect. On timeout the attempt fails, the pool releases the slot, and the
next request establishes a fresh connection.

## Reproduce / verify

Point a client at an endpoint that completes the TCP connect but never
sends the TLS ServerHello (accept the socket, then hold it open without
reading or writing). The client logs `pool: TimedOut` and stays stuck
until restarted.

To confirm the mechanism I ran a build with bb8 instrumented to log its
internal connection counters: against such an endpoint the pool's pending
count stays pinned (the handshake never returns), so it keeps declining to
open a fresh connection. With this change the handshake times out, the
counter is released, and the pool resumes connecting — verified with the
same instrumented build.
