### PR TITLE
fix: password redaction on https proxy connection

### DIFF
--- a/wstunnel/src/tunnel/mod.rs
+++ b/wstunnel/src/tunnel/mod.rs
@@ -6,13 +6,13 @@ mod tls_reloader;
 pub mod transport;
 
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::path::PathBuf;
 use std::time::Duration;
 use url::Host;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LocalProtocol {
     Tcp {
         proxy_protocol: bool,
@@ -74,6 +74,61 @@ impl LocalProtocol {
     }
 }
 
+impl Debug for LocalProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn redacted(credentials: &Option<(String, String)>) -> Option<&'static str> {
+            credentials.as_ref().map(|_| "<redacted>")
+        }
+
+        match self {
+            Self::Tcp { proxy_protocol } => f
+                .debug_struct("Tcp")
+                .field("proxy_protocol", proxy_protocol)
+                .finish(),
+            Self::Udp { timeout } => f.debug_struct("Udp").field("timeout", timeout).finish(),
+            Self::Stdio { proxy_protocol } => f
+                .debug_struct("Stdio")
+                .field("proxy_protocol", proxy_protocol)
+                .finish(),
+            Self::Socks5 { timeout, credentials } => f
+                .debug_struct("Socks5")
+                .field("timeout", timeout)
+                .field("credentials", &redacted(credentials))
+                .finish(),
+            Self::TProxyTcp => f.write_str("TProxyTcp"),
+            Self::TProxyUdp { timeout } => f.debug_struct("TProxyUdp").field("timeout", timeout).finish(),
+            Self::HttpProxy {
+                timeout,
+                credentials,
+                proxy_protocol,
+            } => f
+                .debug_struct("HttpProxy")
+                .field("timeout", timeout)
+                .field("credentials", &redacted(credentials))
+                .field("proxy_protocol", proxy_protocol)
+                .finish(),
+            Self::ReverseTcp => f.write_str("ReverseTcp"),
+            Self::ReverseUdp { timeout } => f.debug_struct("ReverseUdp").field("timeout", timeout).finish(),
+            Self::ReverseSocks5 { timeout, credentials } => f
+                .debug_struct("ReverseSocks5")
+                .field("timeout", timeout)
+                .field("credentials", &redacted(credentials))
+                .finish(),
+            Self::ReverseHttpProxy { timeout, credentials } => f
+                .debug_struct("ReverseHttpProxy")
+                .field("timeout", timeout)
+                .field("credentials", &redacted(credentials))
+                .finish(),
+            Self::ReverseUnix { path } => f.debug_struct("ReverseUnix").field("path", path).finish(),
+            Self::Unix { path, proxy_protocol } => f
+                .debug_struct("Unix")
+                .field("path", path)
+                .field("proxy_protocol", proxy_protocol)
+                .finish(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RemoteAddr {
     pub protocol: LocalProtocol,
@@ -93,5 +148,37 @@ pub fn try_to_sock_addr((host, port): (Host, u16)) -> anyhow::Result<SocketAddr>
         Host::Domain(_) => Err(anyhow::anyhow!("Cannot convert domain to socket address")),
         Host::Ipv4(ip) => Ok(SocketAddr::V4(SocketAddrV4::new(ip, port))),
         Host::Ipv6(ip) => Ok(SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_credentials() {
+        let protocol = LocalProtocol::ReverseHttpProxy {
+            timeout: Some(Duration::from_secs(30)),
+            credentials: Some(("cyera".to_string(), "supersecret".to_string())),
+        };
+
+        let rendered = format!("{protocol:?}");
+
+        assert!(!rendered.contains("supersecret"), "password leaked: {rendered}");
+        assert!(!rendered.contains("cyera"), "username leaked: {rendered}");
+        assert!(rendered.contains("<redacted>"), "credentials not redacted: {rendered}");
+        assert!(rendered.contains("Some(30s)"), "non-secret fields should still render: {rendered}");
+    }
+
+    #[test]
+    fn debug_keeps_none_credentials_visible() {
+        let protocol = LocalProtocol::Socks5 {
+            timeout: None,
+            credentials: None,
+        };
+
+        let rendered = format!("{protocol:?}");
+
+        assert!(rendered.contains("credentials: None"), "expected None credentials: {rendered}");
     }
 }


### PR DESCRIPTION
## Problem
The server logs proxy/socks5 credentials in cleartext. LocalProtocol
derives Debug, and several log statements print it with {:?} — most
notably tunnel/server/server.rs:
    info!("connected to {:?} {}:{}", req_protocol, ...);
The derived Debug prints every field of the matched variant verbatim,
including the credentials: Option<(String, String)> tuple carried by the
Socks5, HttpProxy, ReverseSocks5, and ReverseHttpProxy variants. So a
reverse HTTP proxy tunnel emits the username and password straight into
the logs:
    connected to ReverseHttpProxy { timeout: Some(30s),
    credentials: Some(("username", "dummypassword")) } host:443
Anyone with access to the logs (aggregators, stdout capture, etc.) can
read the proxy password. The leak is not limited to that one line — any
{:?} on a LocalProtocol (directly, or indirectly via RemoteAddr) exposes
the same secret.
## Fix
Replace the derived Debug on LocalProtocol with a manual impl that
redacts the credentials tuple, rendering it as Some("<redacted>") while
still printing all non-secret fields (timeout, proxy_protocol, path).
Because the fix lives in the Debug impl rather than at a single call
site, it closes the leak everywhere LocalProtocol is debug-formatted.
The match is exhaustive and destructures each variant by name (no `..`),
so adding a new variant or field is a compile error — forcing future
changes to consciously handle (and redact) any new secret rather than
leaking it silently like the derived impl did.

## Reproduce / verify

Built the patched wstunnel image and ran it as the server, then drove real reverse HTTP proxy tunnel traffic through it.
Before the change, the connection log for a ReverseHttpProxy tunnel
printed the credentials tuple verbatim:
    connected to ReverseHttpProxy { timeout: Some(30s),
    credentials: Some(("username", "<password>")) } host:443
With the change, the same code path no longer exposes the secret — the
credentials are redacted while the non-secret fields still render:
    INFO ...wstunnel::tunnel::server::server: connected to
    ReverseHttpProxy { timeout: Some(30s), credentials: Some(...) }
    host:443