### PR TITLE
fix: missing timer on non-TLS server causes panic (process abort) on malformed connections

### DIFF
--- a/wstunnel/src/tunnel/server/server.rs
+++ b/wstunnel/src/tunnel/server/server.rs
@@ -506,6 +506,8 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
                     let fut = async move {
                         let stream = hyper_util::rt::TokioIo::new(stream);
                         let mut conn_fut = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+                        conn_fut.http1().timer(TokioTimer::new());
+                        conn_fut.http2().timer(TokioTimer::new());
                         if let Some(ping) = server.config.websocket_ping_frequency {
                             conn_fut.http2().keep_alive_interval(ping);
                         }


### PR DESCRIPTION
## What

Adds the missing `.timer()` registration on the non-TLS `auto::Builder`
in the server accept loop.

## Why

`server.rs`'s non-TLS branch sets `conn_fut.http2().keep_alive_interval(ping)`
(since `websocket_ping_frequency` defaults to `Some(30s)`), but never calls
`.timer(...)` on the builder. hyper's http2 keep-alive needs a registered
timer; without one it panics with `You must supply a timer.` as soon as a
connection reaches that code path — in practice triggered by malformed/
non-websocket traffic (port scanners hitting the port are enough).

Because the workspace sets `panic = "abort"`, this brings down the whole
process, not just that connection — so a single scanner probe can take
out a running tunnel until something restarts it.

The two TLS branches just above this one already call `.timer(TokioTimer::new())`
on their respective builders — this PR brings the non-TLS path in line.
Same root cause class as #334.

## Repro

Run a plain (non-TLS) `wstunnel server ws://[::]:PORT` with default
`--websocket-ping-frequency-sec`, then send it malformed/non-websocket
traffic (or just leave it on the open internet for a while — port
scanners do it reliably). Logs before the crash:

```
ERROR cnx{...}: wstunnel::tunnel::server::server: Error while upgrading cnx to websocket: hyper::Error(Parse(Method))
ERROR cnx{...}: wstunnel::tunnel::server::server: Invalid protocol version request, got HTTP/1.1 while expecting either websocket http1 upgrade or http2
thread 'tokio-rt-worker' panicked at .../hyper-1.9.0/src/common/time.rs:37:17:
You must supply a timer.
```

## Fix

```diff
 let mut conn_fut = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+conn_fut.http1().timer(TokioTimer::new());
+conn_fut.http2().timer(TokioTimer::new());
 if let Some(ping) = server.config.websocket_ping_frequency {
     conn_fut.http2().keep_alive_interval(ping);
 }
```

Verified `Http1Builder`/`Http2Builder` in `hyper-util` 0.1.20 both expose
`.timer()`, mirroring the API already used in the TLS branches.