### PR TITLE
feat: print actual listen address when binding to :0

### DIFF
--- a/wstunnel/src/protocols/http_proxy/server.rs
+++ b/wstunnel/src/protocols/http_proxy/server.rs
@@ -151,14 +151,15 @@ pub async fn run_server(
     timeout: Option<Duration>,
     credentials: Option<(String, String)>,
 ) -> Result<HttpProxyListener, anyhow::Error> {
-    info!(
-        "Starting http proxy server listening cnx on {bind} with credential {:?}",
-        credentials.as_ref().map(|x| (&x.0, "xxx"))
-    );
-
     let listener = TcpListener::bind(bind)
         .await
         .with_context(|| format!("Cannot create TCP server {bind:?}"))?;
+
+    info!(
+        "Starting http proxy server listening cnx on {} with credential {:?}",
+        listener.local_addr().unwrap_or(bind),
+        credentials.as_ref().map(|x| (&x.0, "xxx"))
+    );
 
     let http1 = {
         let mut builder = http1::Builder::new();

--- a/wstunnel/src/protocols/socks5/tcp_server.rs
+++ b/wstunnel/src/protocols/socks5/tcp_server.rs
@@ -77,14 +77,14 @@ pub async fn run_server(
     timeout: Option<Duration>,
     credentials: Option<(String, String)>,
 ) -> Result<Socks5Listener, anyhow::Error> {
-    info!(
-        "Starting SOCKS5 server listening cnx on {} with credentials {:?}",
-        bind, credentials
-    );
-
     let listener = TcpListener::bind(bind)
         .await
         .with_context(|| format!("Cannot create socks5 server {bind:?}"))?;
+
+    info!(
+        "Starting SOCKS5 server listening cnx on {} with credentials {:?}",
+        listener.local_addr().unwrap_or(bind), credentials
+    );
 
     let udp_server = super::udp_server::run_server(bind, timeout).await?;
     let stream = stream::unfold(

--- a/wstunnel/src/protocols/tcp/server.rs
+++ b/wstunnel/src/protocols/tcp/server.rs
@@ -210,11 +210,11 @@ pub async fn connect_with_http_proxy(
 
 #[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
 pub async fn run_server(bind: SocketAddr, ip_transparent: bool) -> Result<TcpListenerStream, anyhow::Error> {
-    info!("Starting TCP server listening cnx on {bind}");
-
     let listener = TcpListener::bind(bind)
         .await
         .with_context(|| format!("Cannot create TCP server {bind:?}"))?;
+
+    info!("Starting TCP server listening cnx on {}", listener.local_addr().unwrap_or(bind));
 
     #[cfg(target_os = "linux")]
     if ip_transparent {

--- a/wstunnel/src/protocols/udp/server.rs
+++ b/wstunnel/src/protocols/udp/server.rs
@@ -243,16 +243,16 @@ pub async fn run_server(
     configure_listener: impl Fn(&UdpSocket) -> anyhow::Result<()>,
     mk_send_socket: impl Fn(&Arc<UdpSocket>) -> anyhow::Result<Arc<UdpSocket>>,
 ) -> Result<impl Stream<Item = io::Result<UdpStream>>, anyhow::Error> {
-    info!(
-        "Starting UDP server listening cnx on {} with cnx timeout of {}s",
-        bind,
-        timeout.unwrap_or(Duration::from_secs(0)).as_secs()
-    );
-
     let listener = UdpSocket::bind(bind)
         .await
         .with_context(|| format!("Cannot create UDP server {bind:?}"))?;
     configure_listener(&listener)?;
+
+    info!(
+        "Starting UDP server listening cnx on {} with cnx timeout of {}s",
+        listener.local_addr().unwrap_or(bind),
+        timeout.unwrap_or(Duration::from_secs(0)).as_secs()
+    );
 
     let udp_server = UdpServer::new(listener, timeout);
     let stream = stream::unfold(

--- a/wstunnel/src/tunnel/server/server.rs
+++ b/wstunnel/src/tunnel/server/server.rs
@@ -331,8 +331,6 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
     }
 
     pub async fn serve(self, restrictions: RestrictionsRules) -> anyhow::Result<()> {
-        info!("Starting wstunnel server listening on {}", self.config.bind);
-
         // setup upgrade request handler
         let mk_websocket_upgrade_fn = |server: WsServer<_>,
                                        restrictions: Arc<ArcSwap<RestrictionsRules>>,
@@ -423,6 +421,8 @@ impl<E: crate::TokioExecutorRef> WsServer<E> {
         let listener = TcpListener::bind(&self.config.bind)
             .await
             .with_context(|| format!("Failed to bind to socket on {}", self.config.bind))?;
+
+        info!("Starting wstunnel server listening on {}", listener.local_addr().unwrap_or(self.config.bind));
 
         loop {
             let (stream, peer_addr) = match listener.accept().await {


### PR DESCRIPTION
- Changes the logging behavior to print out the listen address using `listener.local_addr()` after its successfully bound.
- This is so that its easier for the user to figure out which port `wstunnel` is bound to when using `127.0.0.1:0`.
- Normally the user will have to use `ss` or `lsof` to figure that out, now `wstunnel` prints it out directly

Resolves #524 
