### PR TITLE
ci: run tests, formatting and lint checks on pull requests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# A new push to a pull request supersedes the run still in flight. Pushes to branches and tags
+# are never cancelled, as they are what feeds the release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   RUST_VERSION: 1.95.0
   BIN_NAME: "wstunnel"
@@ -31,6 +37,9 @@ jobs:
         with:
           tool: taplo-cli,cargo-nextest
 
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
@@ -42,8 +51,13 @@ jobs:
 
       # Not --all-features: it turns on both `aws-lc-rs` and `ring`, which forward the two
       # mutually exclusive crypto providers of jsonwebtoken, and the tests then panic at runtime.
-      - name: Test
+      # Each provider gets its own run instead, as they are compiled in, never side by side.
+      - name: Test with aws-lc-rs
         run: cargo nextest run --locked
+
+      # What the armv7, armv6, freebsd and windows-x86 builds ship with.
+      - name: Test with ring
+        run: cargo nextest run --locked --no-default-features --features ring
 
   build:
     name: Build - ${{ matrix.platform.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,40 @@ env:
   BIN_NAME: "wstunnel"
 
 jobs:
+  # Runs alongside the build matrix, so a formatting or test failure is reported without
+  # waiting on the cross-compilation of every platform.
+  check:
+    name: Check - format, lint & tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Git repo
+        uses: actions/checkout@v4
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "${{ env.RUST_VERSION }}"
+          components: rustfmt, clippy
+
+      - name: Install taplo-cli and cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli,cargo-nextest
+
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check TOML formatting
+        run: taplo fmt --check
+
+      - name: Lint
+        run: cargo clippy --all --all-features --locked -- -D warnings
+
+      # Not --all-features: it turns on both `aws-lc-rs` and `ring`, which forward the two
+      # mutually exclusive crypto providers of jsonwebtoken, and the tests then panic at runtime.
+      - name: Test
+        run: cargo nextest run --locked
+
   build:
     name: Build - ${{ matrix.platform.name }}
     # By default, runs on Ubuntu, otherwise, override with the desired os
@@ -132,10 +166,8 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Install bindgen-cli
+        if: contains(matrix.platform.build-args, 'aws-lc-rs-bindgen')
         run: cargo install bindgen-cli
-
-      - name: Install taplo-cli
-        run: cargo install taplo-cli --locked
 
       - name: Show command used for Cargo
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+## What you need
+
+Building needs a Rust toolchain — the CI pins **1.95.0**, and the crates are on edition 2024.
+
+Beyond that, the checks need:
+
+* [cargo-nextest](https://nexte.st) to run the tests
+* a running Docker daemon, as one test spins up a mitmproxy container
+* [taplo](https://taplo.tamasfe.dev) to format the TOML files
+
+## Tasks
+
+The repository ships a [justfile](justfile) and a [mise.toml](mise.toml) with the same tasks.
+Use whichever tool you already have:
+
+```bash
+just fmt          # cargo fmt --all, then taplo fmt
+just test         # cargo nextest run
+just linter_fix   # cargo clippy --fix
+```
+
+```bash
+mise run linter-fix   # cargo clippy --fix, then cargo fmt --all
+mise run test         # cargo nextest run
+```
+
+## Before opening a pull request
+
+CI runs the following on every pull request. Running them locally first saves a round trip:
+
+```bash
+cargo fmt --all -- --check
+taplo fmt --check
+cargo clippy --all --all-features --locked -- -D warnings
+cargo nextest run --locked
+cargo nextest run --locked --no-default-features --features ring
+```
+
+The test suite is run once per crypto provider. `--all-features` does **not** work for it: it
+enables both `aws-lc-rs` and `ring`, which forward jsonwebtoken the two providers it treats as
+mutually exclusive, and every test going through a tunnel then panics. The providers are
+compiled in, never used side by side, so they are tested one at a time.
+
+`ring` is worth running because the armv7, armv6, freebsd and windows-x86 binaries ship with it,
+while the default `aws-lc-rs` covers every other platform.
+
+## Reporting an issue
+
+Issues must follow one of the [templates](.github/ISSUE_TEMPLATE); a bot closes the ones that do
+not.

--- a/justfile
+++ b/justfile
@@ -30,8 +30,10 @@ docker_release $TAG:
     --push .
   docker buildx rm builder
 
+# Not --all-features: it turns on both `aws-lc-rs` and `ring`, which forward the two mutually
+# exclusive crypto providers of jsonwebtoken, and the tests then panic at runtime.
 test:
-   cargo nextest run --all-features
+   cargo nextest run
 
 bump_deps:
   cargo upgrade  --recursive true --incompatible allow

--- a/mise.toml
+++ b/mise.toml
@@ -3,8 +3,10 @@
 #rust = "1.93"
 
 [tasks.test]
-description = "Run all the tests with features. Requires docker"
-run = "cargo nextest run --all-features"
+description = "Run all the tests. Requires docker"
+# Not --all-features: it turns on both `aws-lc-rs` and `ring`, which forward the two mutually
+# exclusive crypto providers of jsonwebtoken, and the tests then panic at runtime.
+run = "cargo nextest run"
 
 [tasks.bump-deps]
 description = "Upgrade all libs versions for all packages"

--- a/wstunnel/Cargo.toml
+++ b/wstunnel/Cargo.toml
@@ -57,10 +57,7 @@ derive_more = { version = "2.1.1", features = ["display", "error"] }
 
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "tls12"] }
 rcgen = { version = "0.14.8", default-features = false, features = [] }
-hickory-resolver = { version = "0.26.1", default-features = false, features = [
-  "system-config",
-  "tokio",
-] }
+hickory-resolver = { version = "0.26.1", default-features = false, features = ["system-config", "tokio"] }
 aws-lc-rs = { version = "*", optional = true }
 
 [target.'cfg(not(target_family = "unix"))'.dependencies]
@@ -87,7 +84,13 @@ aws-lc-rs = [
   "rcgen/aws_lc_rs",
   "hickory-resolver/tls-aws-lc-rs",
   "hickory-resolver/https-aws-lc-rs",
-  "jsonwebtoken/aws_lc_rs"
+  "jsonwebtoken/aws_lc_rs",
 ]
 aws-lc-rs-bindgen = ["dep:aws-lc-rs", "aws-lc-rs/bindgen"]
-ring = ["tokio-rustls/ring", "rcgen/ring", "hickory-resolver/tls-ring", "hickory-resolver/https-ring", "jsonwebtoken/rust_crypto"]
+ring = [
+  "tokio-rustls/ring",
+  "rcgen/ring",
+  "hickory-resolver/tls-ring",
+  "hickory-resolver/https-ring",
+  "jsonwebtoken/rust_crypto",
+]

--- a/wstunnel/Cargo.toml
+++ b/wstunnel/Cargo.toml
@@ -42,7 +42,8 @@ rustls-native-certs = { version = "0.8.4", features = [] }
 rustls-pemfile = { version = "2.2.0", features = [] }
 # WebTransport (HTTP/3 over QUIC) transport. Takes our own rustls config, so the
 # crypto provider follows from the aws-lc-rs/ring features below. Re-exports quinn.
-web-transport-quinn = { version = "0.11.12", features = [] }
+# Its default feature is aws-lc-rs, which would pull aws-lc-sys into the ring builds.
+web-transport-quinn = { version = "0.11.12", default-features = false, features = [] }
 x509-parser = "0.18.1"
 serde = { version = "1.0.229", features = ["derive"] }
 socket2 = { version = "0.6.5", features = ["all"] }
@@ -85,6 +86,7 @@ aws-lc-rs = [
   "hickory-resolver/tls-aws-lc-rs",
   "hickory-resolver/https-aws-lc-rs",
   "jsonwebtoken/aws_lc_rs",
+  "web-transport-quinn/aws-lc-rs",
 ]
 aws-lc-rs-bindgen = ["dep:aws-lc-rs", "aws-lc-rs/bindgen"]
 ring = [
@@ -93,4 +95,5 @@ ring = [
   "hickory-resolver/tls-ring",
   "hickory-resolver/https-ring",
   "jsonwebtoken/rust_crypto",
+  "web-transport-quinn/ring",
 ]

--- a/wstunnel/src/test_integrations.rs
+++ b/wstunnel/src/test_integrations.rs
@@ -17,13 +17,44 @@ use regex::Regex;
 use rstest::{fixture, rstest};
 use scopeguard::defer;
 use serial_test::serial;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::pin;
 use url::Host;
+
+/// Ports already handed out by [`free_port`] in this process. A port becomes free again as soon
+/// as the probe socket is dropped, so without this two calls could hand out the same one.
+static HANDED_OUT_PORTS: Mutex<BTreeSet<u16>> = Mutex::new(BTreeSet::new());
+
+/// Reserve a loopback port that is free for both TCP and UDP.
+///
+/// Webtransport serves QUIC/UDP on the same port as the TCP listener, so a port free for only
+/// one of the two would make its tests flaky. Both probe sockets are dropped before returning:
+/// the port is picked, not held, and the caller binds it right after.
+fn free_port() -> u16 {
+    loop {
+        let tcp = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("Cannot bind a free TCP port");
+        let port = tcp.local_addr().expect("Cannot read the bound TCP port").port();
+        drop(tcp);
+
+        if HANDED_OUT_PORTS.lock().unwrap().insert(port)
+            && std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, port)).is_ok()
+        {
+            return port;
+        }
+    }
+}
+
+/// A loopback address on a free port, with its host apart, as tunnel listeners take both.
+fn free_addr() -> (SocketAddr, Host) {
+    (
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, free_port())),
+        Host::Ipv4(Ipv4Addr::LOCALHOST),
+    )
+}
 
 #[fixture]
 fn dns_resolver() -> DnsResolver {
@@ -40,7 +71,7 @@ fn dns_resolver() -> DnsResolver {
 fn server_no_tls(dns_resolver: DnsResolver) -> WsServer {
     let server_config = WsServerConfig {
         socket_so_mark: SoMark::new(None),
-        bind: "127.0.0.1:8080".parse().unwrap(),
+        bind: free_addr().0,
         websocket_ping_frequency: Some(Duration::from_secs(10)),
         timeout_connect: Duration::from_secs(10),
         websocket_mask_frame: false,
@@ -59,7 +90,7 @@ fn server_no_tls(dns_resolver: DnsResolver) -> WsServer {
 fn server_webtransport(dns_resolver: DnsResolver) -> WsServer {
     let server_config = WsServerConfig {
         socket_so_mark: SoMark::new(None),
-        bind: "127.0.0.1:8080".parse().unwrap(),
+        bind: free_addr().0,
         websocket_ping_frequency: Some(Duration::from_secs(10)),
         timeout_connect: Duration::from_secs(10),
         websocket_mask_frame: false,
@@ -80,8 +111,8 @@ fn server_webtransport(dns_resolver: DnsResolver) -> WsServer {
     WsServer::new(server_config, DefaultTokioExecutor::default())
 }
 
-#[fixture]
-async fn client_webtransport(dns_resolver: DnsResolver) -> WsClient {
+/// Not a fixture, as the port to dial is only known once the server fixture has picked one.
+async fn client_webtransport(server_port: u16, dns_resolver: DnsResolver) -> WsClient {
     // The embedded certificate is self-signed with no SAN, so verification must be off.
     let tls_connector =
         crate::protocols::tls::tls_connector(false, TransportScheme::Wts.alpn_protocols(), true, None, None, None)
@@ -96,19 +127,14 @@ async fn client_webtransport(dns_resolver: DnsResolver) -> WsClient {
     };
 
     let client_config = WsClientConfig {
-        remote_addr: TransportAddr::new(
-            TransportScheme::Wts,
-            Host::Ipv4("127.0.0.1".parse().unwrap()),
-            8080,
-            Some(tls),
-        )
-        .unwrap(),
+        remote_addr: TransportAddr::new(TransportScheme::Wts, Host::Ipv4(Ipv4Addr::LOCALHOST), server_port, Some(tls))
+            .unwrap(),
         socket_so_mark: SoMark::new(None),
         http_upgrade_path_prefix: "wstunnel".to_string(),
         http_upgrade_credentials: None,
         http_headers: HashMap::new(),
         http_headers_file: None,
-        http_header_host: HeaderValue::from_static("127.0.0.1:8080"),
+        http_header_host: HeaderValue::from_str(&format!("127.0.0.1:{server_port}")).unwrap(),
         timeout_connect: Duration::from_secs(10),
         websocket_ping_frequency: Some(Duration::from_secs(10)),
         websocket_mask_frame: false,
@@ -127,17 +153,17 @@ async fn client_webtransport(dns_resolver: DnsResolver) -> WsClient {
     .unwrap()
 }
 
-#[fixture]
-async fn client_ws(dns_resolver: DnsResolver) -> WsClient {
+/// Not a fixture, as the port to dial is only known once the server fixture has picked one.
+async fn client_ws(server_port: u16, dns_resolver: DnsResolver) -> WsClient {
     let client_config = WsClientConfig {
-        remote_addr: TransportAddr::new(TransportScheme::Ws, Host::Ipv4("127.0.0.1".parse().unwrap()), 8080, None)
+        remote_addr: TransportAddr::new(TransportScheme::Ws, Host::Ipv4(Ipv4Addr::LOCALHOST), server_port, None)
             .unwrap(),
         socket_so_mark: SoMark::new(None),
         http_upgrade_path_prefix: "wstunnel".to_string(),
         http_upgrade_credentials: None,
         http_headers: HashMap::new(),
         http_headers_file: None,
-        http_header_host: HeaderValue::from_static("127.0.0.1:8080"),
+        http_header_host: HeaderValue::from_str(&format!("127.0.0.1:{server_port}")).unwrap(),
         timeout_connect: Duration::from_secs(10),
         websocket_ping_frequency: Some(Duration::from_secs(10)),
         websocket_mask_frame: false,
@@ -189,41 +215,31 @@ fn no_restrictions() -> RestrictionsRules {
     }
 }
 
-const TUNNEL_LISTEN: (SocketAddr, Host) = (
-    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9998)),
-    Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
-);
-const ENDPOINT_LISTEN: (SocketAddr, Host) = (
-    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9999)),
-    Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
-);
-
 #[rstest]
 #[timeout(Duration::from_secs(10))]
 #[tokio::test]
 #[serial]
-async fn test_tcp_tunnel(
-    #[future] client_ws: WsClient,
-    server_no_tls: WsServer,
-    no_restrictions: RestrictionsRules,
-    dns_resolver: DnsResolver,
-) {
+async fn test_tcp_tunnel(server_no_tls: WsServer, no_restrictions: RestrictionsRules, dns_resolver: DnsResolver) {
+    let (tunnel_listen, tunnel_host) = free_addr();
+    let (endpoint_listen, endpoint_host) = free_addr();
+
+    let server_port = server_no_tls.config.bind.port();
     let server_h = tokio::spawn(server_no_tls.serve(no_restrictions));
     defer! { server_h.abort(); };
 
-    let client_ws = client_ws.await;
+    let client_ws = client_ws(server_port, dns_resolver.clone()).await;
 
-    let server = TcpTunnelListener::new(TUNNEL_LISTEN.0, (ENDPOINT_LISTEN.1, ENDPOINT_LISTEN.0.port()), false)
+    let server = TcpTunnelListener::new(tunnel_listen, (endpoint_host, endpoint_listen.port()), false)
         .await
         .unwrap();
     tokio::spawn(async move {
         client_ws.run_tunnel(server).await.unwrap();
     });
 
-    let mut tcp_listener = protocols::tcp::run_server(ENDPOINT_LISTEN.0, false).await.unwrap();
+    let mut tcp_listener = protocols::tcp::run_server(endpoint_listen, false).await.unwrap();
     let mut client = protocols::tcp::connect(
-        &TUNNEL_LISTEN.1,
-        TUNNEL_LISTEN.0.port(),
+        &tunnel_host,
+        tunnel_listen.port(),
         SoMark::new(None),
         Duration::from_secs(10),
         &dns_resolver,
@@ -247,30 +263,29 @@ async fn test_tcp_tunnel(
 #[timeout(Duration::from_secs(10))]
 #[tokio::test]
 #[serial]
-async fn test_udp_tunnel(
-    #[future] client_ws: WsClient,
-    server_no_tls: WsServer,
-    no_restrictions: RestrictionsRules,
-    dns_resolver: DnsResolver,
-) {
+async fn test_udp_tunnel(server_no_tls: WsServer, no_restrictions: RestrictionsRules, dns_resolver: DnsResolver) {
+    let (tunnel_listen, tunnel_host) = free_addr();
+    let (endpoint_listen, endpoint_host) = free_addr();
+
+    let server_port = server_no_tls.config.bind.port();
     let server_h = tokio::spawn(server_no_tls.serve(no_restrictions));
     defer! { server_h.abort(); };
 
-    let client_ws = client_ws.await;
+    let client_ws = client_ws(server_port, dns_resolver.clone()).await;
 
-    let server = UdpTunnelListener::new(TUNNEL_LISTEN.0, (ENDPOINT_LISTEN.1, ENDPOINT_LISTEN.0.port()), None)
+    let server = UdpTunnelListener::new(tunnel_listen, (endpoint_host, endpoint_listen.port()), None)
         .await
         .unwrap();
     tokio::spawn(async move {
         client_ws.run_tunnel(server).await.unwrap();
     });
 
-    let udp_listener = protocols::udp::run_server(ENDPOINT_LISTEN.0, None, |_| Ok(()), |s| Ok(s.clone()))
+    let udp_listener = protocols::udp::run_server(endpoint_listen, None, |_| Ok(()), |s| Ok(s.clone()))
         .await
         .unwrap();
     let mut client = protocols::udp::connect(
-        &TUNNEL_LISTEN.1,
-        TUNNEL_LISTEN.0.port(),
+        &tunnel_host,
+        tunnel_listen.port(),
         Duration::from_secs(10),
         SoMark::new(None),
         &dns_resolver,
@@ -297,27 +312,30 @@ async fn test_udp_tunnel(
 #[tokio::test]
 #[serial]
 async fn test_tcp_tunnel_webtransport(
-    #[future] client_webtransport: WsClient,
     server_webtransport: WsServer,
     no_restrictions: RestrictionsRules,
     dns_resolver: DnsResolver,
 ) {
+    let (tunnel_listen, tunnel_host) = free_addr();
+    let (endpoint_listen, endpoint_host) = free_addr();
+
+    let server_port = server_webtransport.config.bind.port();
     let server_h = tokio::spawn(server_webtransport.serve(no_restrictions));
     defer! { server_h.abort(); };
 
-    let client = client_webtransport.await;
+    let client = client_webtransport(server_port, dns_resolver.clone()).await;
 
-    let server = TcpTunnelListener::new(TUNNEL_LISTEN.0, (ENDPOINT_LISTEN.1, ENDPOINT_LISTEN.0.port()), false)
+    let server = TcpTunnelListener::new(tunnel_listen, (endpoint_host, endpoint_listen.port()), false)
         .await
         .unwrap();
     tokio::spawn(async move {
         client.run_tunnel(server).await.unwrap();
     });
 
-    let mut tcp_listener = protocols::tcp::run_server(ENDPOINT_LISTEN.0, false).await.unwrap();
+    let mut tcp_listener = protocols::tcp::run_server(endpoint_listen, false).await.unwrap();
     let mut client = protocols::tcp::connect(
-        &TUNNEL_LISTEN.1,
-        TUNNEL_LISTEN.0.port(),
+        &tunnel_host,
+        tunnel_listen.port(),
         SoMark::new(None),
         Duration::from_secs(10),
         &dns_resolver,
@@ -342,29 +360,32 @@ async fn test_tcp_tunnel_webtransport(
 #[tokio::test]
 #[serial]
 async fn test_udp_tunnel_webtransport(
-    #[future] client_webtransport: WsClient,
     server_webtransport: WsServer,
     no_restrictions: RestrictionsRules,
     dns_resolver: DnsResolver,
 ) {
+    let (tunnel_listen, tunnel_host) = free_addr();
+    let (endpoint_listen, endpoint_host) = free_addr();
+
+    let server_port = server_webtransport.config.bind.port();
     let server_h = tokio::spawn(server_webtransport.serve(no_restrictions));
     defer! { server_h.abort(); };
 
-    let client = client_webtransport.await;
+    let client = client_webtransport(server_port, dns_resolver.clone()).await;
 
-    let server = UdpTunnelListener::new(TUNNEL_LISTEN.0, (ENDPOINT_LISTEN.1, ENDPOINT_LISTEN.0.port()), None)
+    let server = UdpTunnelListener::new(tunnel_listen, (endpoint_host, endpoint_listen.port()), None)
         .await
         .unwrap();
     tokio::spawn(async move {
         client.run_tunnel(server).await.unwrap();
     });
 
-    let udp_listener = protocols::udp::run_server(ENDPOINT_LISTEN.0, None, |_| Ok(()), |s| Ok(s.clone()))
+    let udp_listener = protocols::udp::run_server(endpoint_listen, None, |_| Ok(()), |s| Ok(s.clone()))
         .await
         .unwrap();
     let mut client = protocols::udp::connect(
-        &TUNNEL_LISTEN.1,
-        TUNNEL_LISTEN.0.port(),
+        &tunnel_host,
+        tunnel_listen.port(),
         Duration::from_secs(10),
         SoMark::new(None),
         &dns_resolver,

--- a/wstunnel/src/test_integrations.rs
+++ b/wstunnel/src/test_integrations.rs
@@ -58,12 +58,13 @@ fn free_addr() -> (SocketAddr, Host) {
 
 #[fixture]
 fn dns_resolver() -> DnsResolver {
-    if tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .is_err()
-    {
-        let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
-    }
+    // Whichever provider the crate was built with, as only one of the two is compiled in.
+    // Installing twice is expected across fixtures, hence the ignored result.
+    #[cfg(feature = "aws-lc-rs")]
+    let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    let _ = tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+
     DnsResolver::new_from_urls(&[], None, SoMark::new(None), true).expect("Cannot create DNS resolver")
 }
 


### PR DESCRIPTION
CI only cross-compiles — no tests, no fmt, no clippy, even though the workflow already installs
rustfmt, clippy and taplo without ever calling them. That's how `just test` could stay broken:
`--all-features` enables both aws-lc-rs and ring, and jsonwebtoken panics on the two conflicting
crypto providers.

So: a check job running fmt/taplo/clippy/tests on both providers, `--all-features` dropped from
the test task, and integration tests picking free ports instead of hardcoded 8080/9998/9999 —
that last one also fixes the flaky webtransport test and takes the suite from ~50s to ~2s.
Commits are independent if you'd rather take them separately.

Couldn't run `test_proxy_connection` locally, it needs docker.
