### PR TITLE
ci: add windows aarch64 build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,12 @@ jobs:
             target: i686-pc-windows-msvc
             build-args: "--profile release-with-symbols --no-default-features --features ring"
 
+          # ring rather than aws-lc-rs, as aws-lc-sys needs NASM, which has no aarch64 backend.
+          - name: Windows aarch64
+            os: windows-2022
+            target: aarch64-pc-windows-msvc
+            build-args: "--profile release-with-symbols --no-default-features --features ring"
+
     steps:
 
       - name: Install package for linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,6 @@ builds:
     binary: wstunnel
     ignore:
       - goos: windows
-        goarch: arm64
-      - goos: windows
         goarch: arm
       - goos: darwin
         goarch: arm


### PR DESCRIPTION
Closes #526 — Snapdragon X laptops made this a real target.

The runner image already ships the MSVC ARM64 tools, so it only needs the matrix entry and
lifting the goreleaser ignore. `.goreleaser_hook.sh` already maps `arm64` to `aarch64`, so it is
unchanged. Uses ring like the windows x86 build does, since aws-lc-sys assembles through NASM,
which has no aarch64 backend.

Verified on a fork run: the job passes and the artifact is a `PE32+ executable (console) Aarch64`.
