### PR TITLE
fix: preserve UDP packet boundaries over WebTransport streams

### DIFF
--- a/wstunnel/src/tunnel/client/client.rs
+++ b/wstunnel/src/tunnel/client/client.rs
@@ -1,7 +1,6 @@
 use crate::executor::{DefaultTokioExecutor, TokioExecutorRef};
 use crate::protocols::tls;
 use crate::tunnel;
-use crate::tunnel::RemoteAddr;
 use crate::tunnel::client::WsClientConfig;
 use crate::tunnel::client::cnx_pool::WsConnection;
 use crate::tunnel::connectors::TunnelConnector;
@@ -10,6 +9,7 @@ use crate::tunnel::tls_reloader::TlsReloader;
 use crate::tunnel::transport::io::{TunnelReader, TunnelWriter};
 use crate::tunnel::transport::webtransport::WebTransportEndpoint;
 use crate::tunnel::transport::{TransportScheme, jwt_token_to_tunnel};
+use crate::tunnel::{LocalProtocol, RemoteAddr};
 use anyhow::{Context, anyhow};
 use futures_util::pin_mut;
 use hyper::header::COOKIE;
@@ -125,11 +125,19 @@ impl<E: TokioExecutorRef> WsClient<E> {
             TransportScheme::Wts => tunnel::transport::webtransport::connect(request_id, self, remote_cfg)
                 .await
                 .map(|(r, w, response)| {
-                    (
-                        TunnelReader::WebTransport(Box::new(r)),
-                        TunnelWriter::WebTransport(Box::new(w)),
-                        response,
-                    )
+                    if matches!(remote_cfg.protocol, LocalProtocol::Udp { .. } | LocalProtocol::TProxyUdp { .. }) {
+                        (
+                            TunnelReader::WebTransportUdpStream(Box::new(r.into_udp_stream())),
+                            TunnelWriter::WebTransportUdpStream(Box::new(w.into_udp_stream())),
+                            response,
+                        )
+                    } else {
+                        (
+                            TunnelReader::WebTransport(Box::new(r)),
+                            TunnelWriter::WebTransport(Box::new(w)),
+                            response,
+                        )
+                    }
                 })?,
         };
 

--- a/wstunnel/src/tunnel/server/handler_webtransport.rs
+++ b/wstunnel/src/tunnel/server/handler_webtransport.rs
@@ -1,12 +1,14 @@
 use crate::executor::TokioExecutorRef;
 use crate::protocols::tls;
 use crate::restrictions::types::RestrictionsRules;
+use crate::tunnel::LocalProtocol;
 use crate::tunnel::server::WsServer;
 use crate::tunnel::tls_reloader::TlsReloader;
 use crate::tunnel::transport;
 use crate::tunnel::transport::tunnel_to_jwt_token;
 use crate::tunnel::transport::webtransport::{
-    WebTransportTunnelRead, WebTransportTunnelWrite, bind_udp_socket, mk_transport_config, write_jwt_preamble,
+    WebTransportTunnelRead, WebTransportTunnelReadUdpStream, WebTransportTunnelWrite, WebTransportTunnelWriteUdpStream,
+    bind_udp_socket, mk_transport_config, write_jwt_preamble,
 };
 use anyhow::{Context, anyhow};
 use arc_swap::ArcSwap;
@@ -180,19 +182,46 @@ async fn handle_session(
     }
 
     let (close_tx, close_rx) = oneshot::channel::<()>();
-    server.executor.spawn(
-        transport::io::propagate_remote_to_local(
-            local_tx,
-            WebTransportTunnelRead::new(recv, session.clone()),
-            close_rx,
-        )
-        .instrument(Span::current()),
-    );
-
-    server.executor.spawn(
-        transport::io::propagate_local_to_remote(local_rx, WebTransportTunnelWrite::new(send, session), close_tx, None)
+    if matches!(
+        remote_addr.protocol,
+        LocalProtocol::Udp { .. } | LocalProtocol::TProxyUdp { .. }
+    ) {
+        server.executor.spawn(
+            transport::io::propagate_remote_to_local(
+                local_tx,
+                WebTransportTunnelReadUdpStream::new(recv, session.clone()),
+                close_rx,
+            )
             .instrument(Span::current()),
-    );
+        );
+        server.executor.spawn(
+            transport::io::propagate_local_to_remote(
+                local_rx,
+                WebTransportTunnelWriteUdpStream::new(send, session),
+                close_tx,
+                None,
+            )
+            .instrument(Span::current()),
+        );
+    } else {
+        server.executor.spawn(
+            transport::io::propagate_remote_to_local(
+                local_tx,
+                WebTransportTunnelRead::new(recv, session.clone()),
+                close_rx,
+            )
+            .instrument(Span::current()),
+        );
+        server.executor.spawn(
+            transport::io::propagate_local_to_remote(
+                local_rx,
+                WebTransportTunnelWrite::new(send, session),
+                close_tx,
+                None,
+            )
+            .instrument(Span::current()),
+        );
+    }
 
     Ok(())
 }

--- a/wstunnel/src/tunnel/transport/io.rs
+++ b/wstunnel/src/tunnel/transport/io.rs
@@ -1,6 +1,8 @@
 use crate::tunnel::transport::http2::{Http2TunnelRead, Http2TunnelWrite};
 use crate::tunnel::transport::websocket::{WebsocketTunnelRead, WebsocketTunnelWrite};
-use crate::tunnel::transport::webtransport::{WebTransportTunnelRead, WebTransportTunnelWrite};
+use crate::tunnel::transport::webtransport::{
+    WebTransportTunnelRead, WebTransportTunnelReadUdpStream, WebTransportTunnelWrite, WebTransportTunnelWriteUdpStream,
+};
 use bytes::{BufMut, BytesMut};
 use futures_util::{FutureExt, pin_mut};
 use std::future::Future;
@@ -39,6 +41,7 @@ pub enum TunnelReader {
     // Boxed: a quinn RecvStream plus the session handle is several times the size of the other
     // variants, and would otherwise inflate the enum for every tunnel.
     WebTransport(Box<WebTransportTunnelRead>),
+    WebTransportUdpStream(Box<WebTransportTunnelReadUdpStream>),
 }
 
 impl TunnelRead for TunnelReader {
@@ -47,6 +50,7 @@ impl TunnelRead for TunnelReader {
             Self::Websocket(s) => s.copy(writer).await,
             Self::Http2(s) => s.copy(writer).await,
             Self::WebTransport(s) => s.copy(writer).await,
+            Self::WebTransportUdpStream(s) => s.copy(writer).await,
         }
     }
 }
@@ -56,6 +60,7 @@ pub enum TunnelWriter {
     Http2(Http2TunnelWrite),
     // Boxed for the same reason as `TunnelReader::WebTransport`.
     WebTransport(Box<WebTransportTunnelWrite>),
+    WebTransportUdpStream(Box<WebTransportTunnelWriteUdpStream>),
 }
 
 impl TunnelWrite for TunnelWriter {
@@ -64,6 +69,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.buf_mut(),
             Self::Http2(s) => s.buf_mut(),
             Self::WebTransport(s) => s.buf_mut(),
+            Self::WebTransportUdpStream(s) => s.buf_mut(),
         }
     }
 
@@ -72,6 +78,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.write().await,
             Self::Http2(s) => s.write().await,
             Self::WebTransport(s) => s.write().await,
+            Self::WebTransportUdpStream(s) => s.write().await,
         }
     }
 
@@ -80,6 +87,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.ping().await,
             Self::Http2(s) => s.ping().await,
             Self::WebTransport(s) => s.ping().await,
+            Self::WebTransportUdpStream(s) => s.ping().await,
         }
     }
 
@@ -88,6 +96,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.close().await,
             Self::Http2(s) => s.close().await,
             Self::WebTransport(s) => s.close().await,
+            Self::WebTransportUdpStream(s) => s.close().await,
         }
     }
 
@@ -96,6 +105,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.pending_operations_notify(),
             Self::Http2(s) => s.pending_operations_notify(),
             Self::WebTransport(s) => s.pending_operations_notify(),
+            Self::WebTransportUdpStream(s) => s.pending_operations_notify(),
         }
     }
 
@@ -104,6 +114,7 @@ impl TunnelWrite for TunnelWriter {
             Self::Websocket(s) => s.handle_pending_operations().await,
             Self::Http2(s) => s.handle_pending_operations().await,
             Self::WebTransport(s) => s.handle_pending_operations().await,
+            Self::WebTransportUdpStream(s) => s.handle_pending_operations().await,
         }
     }
 }

--- a/wstunnel/src/tunnel/transport/webtransport.rs
+++ b/wstunnel/src/tunnel/transport/webtransport.rs
@@ -153,6 +153,10 @@ impl WebTransportTunnelRead {
             _session: session,
         }
     }
+
+    pub fn into_udp_stream(self) -> WebTransportTunnelReadUdpStream {
+        WebTransportTunnelReadUdpStream::new(self.inner, self._session)
+    }
 }
 
 impl TunnelRead for WebTransportTunnelRead {
@@ -174,6 +178,102 @@ pub struct WebTransportTunnelWrite {
     _session: Session,
 }
 
+/// WebTransport stream transport for UDP tunnels. QUIC streams do not preserve message
+/// boundaries, so UDP payloads need an explicit length prefix before they enter the stream.
+pub struct WebTransportTunnelReadUdpStream {
+    inner: RecvStream,
+    _session: Session,
+}
+
+impl WebTransportTunnelReadUdpStream {
+    pub fn new(inner: RecvStream, session: Session) -> Self {
+        Self {
+            inner,
+            _session: session,
+        }
+    }
+}
+
+impl TunnelRead for WebTransportTunnelReadUdpStream {
+    async fn copy(&mut self, mut writer: impl AsyncWrite + Unpin + Send) -> Result<(), io::Error> {
+        let mut length = [0u8; 2];
+        self.inner
+            .read_exact(&mut length)
+            .await
+            .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))?;
+        let length = u16::from_be_bytes(length) as usize;
+        let mut packet = vec![0u8; length];
+        self.inner
+            .read_exact(&mut packet)
+            .await
+            .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))?;
+        writer
+            .write_all(&packet)
+            .await
+            .map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))
+    }
+}
+
+pub struct WebTransportTunnelWriteUdpStream {
+    inner: SendStream,
+    buf: BytesMut,
+    _session: Session,
+}
+
+impl WebTransportTunnelWriteUdpStream {
+    pub fn new(inner: SendStream, session: Session) -> Self {
+        Self {
+            inner,
+            buf: BytesMut::with_capacity(MAX_PACKET_LENGTH),
+            _session: session,
+        }
+    }
+}
+
+impl TunnelWrite for WebTransportTunnelWriteUdpStream {
+    fn buf_mut(&mut self) -> &mut BytesMut {
+        &mut self.buf
+    }
+
+    async fn write(&mut self) -> Result<(), io::Error> {
+        let result = match u16::try_from(self.buf.len()) {
+            Ok(length) => {
+                let result = self.inner.write_all(&length.to_be_bytes()).await;
+                match result {
+                    Ok(()) => self.inner.write_all(&self.buf).await,
+                    Err(err) => Err(err),
+                }
+            }
+            Err(_) => {
+                self.buf.clear();
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    "UDP packet is too large for webtransport stream framing",
+                ));
+            }
+        };
+        self.buf.clear();
+        if self.buf.capacity() < MAX_PACKET_LENGTH {
+            self.buf.reserve(MAX_PACKET_LENGTH);
+        }
+        result.map_err(|err| io::Error::new(ErrorKind::ConnectionAborted, err))
+    }
+
+    async fn ping(&mut self) -> Result<(), io::Error> {
+        Ok(())
+    }
+    async fn close(&mut self) -> Result<(), io::Error> {
+        let _ = self.inner.finish();
+        Ok(())
+    }
+    fn pending_operations_notify(&mut self) -> Arc<Notify> {
+        Arc::new(Notify::new())
+    }
+    async fn handle_pending_operations(&mut self) -> Result<(), io::Error> {
+        Ok(())
+    }
+}
+
 impl WebTransportTunnelWrite {
     pub fn new(inner: SendStream, session: Session) -> Self {
         Self {
@@ -181,6 +281,10 @@ impl WebTransportTunnelWrite {
             buf: BytesMut::with_capacity(MAX_PACKET_LENGTH),
             _session: session,
         }
+    }
+
+    pub fn into_udp_stream(self) -> WebTransportTunnelWriteUdpStream {
+        WebTransportTunnelWriteUdpStream::new(self.inner, self._session)
     }
 }
 


### PR DESCRIPTION
## Summary

Fix UDP tunnels over the default WebTransport stream mode by preserving UDP packet boundaries.

QUIC streams are reliable and ordered, but they are byte streams and do not preserve message boundaries. Previously, UDP packets were written directly to a WebTransport stream and read back using arbitrary stream chunks. This could merge or split UDP packets, causing WireGuard and HTTP/3 traffic to experience high latency, poor throughput, or stalled transfers.

## Changes

- Add a 2-byte length prefix for UDP packets carried over WebTransport streams.
- Read complete UDP packets before forwarding them to the UDP socket.
- Apply stream framing only to `udp://` and `tproxy+udp://` tunnels.
- Keep TCP WebTransport tunnels unchanged.

## Validation

Tested with:

- WireGuard traffic over WebTransport stream mode.
- UDP WebTransport integration tests.
- TCP WebTransport integration tests.
