### PR TITLE
fix: support IPv6 server addresses in WebTransport connections

### DIFF
--- a/wstunnel/src/tunnel/client/config.rs
+++ b/wstunnel/src/tunnel/client/config.rs
@@ -29,6 +29,19 @@ pub struct WsClientConfig {
 }
 
 impl WsClientConfig {
+    pub fn quic_server_name(&self) -> String {
+        self.remote_addr
+            .tls()
+            .and_then(|tls| tls.tls_sni_override.as_ref())
+            .map_or_else(
+                || match &self.remote_addr.host() {
+                    Host::Domain(domain) => domain.clone(),
+                    Host::Ipv4(ip) => ip.to_string(),
+                    Host::Ipv6(ip) => ip.to_string(),
+                },
+                |sni_override| sni_override.as_ref().to_string(),
+            )
+    }
     pub fn tls_server_name(&self) -> ServerName<'static> {
         static INVALID_DNS_NAME: LazyLock<DnsName> =
             LazyLock::new(|| DnsName::try_from("dns-name-invalid.com").unwrap());

--- a/wstunnel/src/tunnel/transport/webtransport.rs
+++ b/wstunnel/src/tunnel/transport/webtransport.rs
@@ -303,11 +303,7 @@ pub async fn connect(
 
     // The SNI name is independent of the address we dial, so --tls-sni-override is just a
     // different name here.
-    let sni = client_cfg
-        .remote_addr
-        .tls()
-        .and_then(|tls| tls.tls_sni_override.as_ref())
-        .map_or_else(|| host.to_string(), |sni| sni.as_ref().to_string());
+    let sni = client_cfg.quic_server_name();
 
     let authority = match host {
         Host::Ipv6(ip) => format!("[{ip}]:{port}"),


### PR DESCRIPTION
## Summary

Fix WebTransport connections to IPv6 server addresses.

When the `wts://` server URL uses an IPv6 address, the address includes brackets as required by URL syntax:
```
"wts://[xx:c021:xx:3eee:xx:c01b:xx:xx]:5992"
```
The WebTransport client previously reused this bracketed host as the QUIC server name. Quinn rejected it with:
```text
ERROR tunnel{id="019ff4d9-5d7e-73c0-86ec-18976e6c8c7f" remote="127.0.0.1:51820"}: wstunnel::tunnel::client::client: failed to open a webtransport session with the server wts://[xx:c021:xx:3eee:xx:c01b:xx:xx]:5992

Caused by:
    0: cannot start a QUIC connection to [xx:c021:xx:3eee:xx:c01b:xx:xx]:5992
    1: invalid server name: [xx:c021:xx:3eee:xx:c01b:xx:xx]
```