### PR TITLE
feat: configure tokio runtime worker threads via --nb-worker-threads flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ Options:
           [default: 0]
 
       --nb-worker-threads <INT>
-          *WARNING* The flag does nothing, you need to set the env variable *WARNING*
           Control the number of threads that will be used.
           By default, it is equal the number of cpus
           
@@ -329,7 +328,6 @@ Options:
           [default: 30s]
 
       --nb-worker-threads <INT>
-          *WARNING* The flag does nothing, you need to set the env variable *WARNING*
           Control the number of threads that will be used.
           By default, it is equal the number of cpus
           

--- a/wstunnel-cli/src/main.rs
+++ b/wstunnel-cli/src/main.rs
@@ -29,7 +29,6 @@ pub struct Wstunnel {
     #[arg(long, global = true, verbatim_doc_comment, env = "NO_COLOR")]
     no_color: bool,
 
-    /// *WARNING* The flag does nothing, you need to set the env variable *WARNING*
     /// Control the number of threads that will be used.
     /// By default, it is equal the number of cpus
     #[arg(
@@ -60,8 +59,7 @@ pub enum Commands {
     Server(Box<Server>),
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let args = Wstunnel::parse();
 
     // Setup logging
@@ -93,25 +91,39 @@ async fn main() -> anyhow::Result<()> {
         warn!("Failed to set soft file limit to hard file limit: {}", err)
     }
 
-    // Start system CA reloader
-    SystemCaReloader::start(None);
-
-    match args.commands {
-        Commands::Client(args) => {
-            run_client(*args, DefaultTokioExecutor::default())
-                .await
-                .unwrap_or_else(|err| {
-                    panic!("Cannot start wstunnel client: {err:?}");
-                });
+    // Build the Tokio runtime
+    let mut builder = match args.nb_worker_threads {
+        Some(1) => tokio::runtime::Builder::new_current_thread(),
+        Some(n) => {
+            let mut b = tokio::runtime::Builder::new_multi_thread();
+            b.worker_threads(n as usize);
+            b
         }
-        Commands::Server(args) => {
-            run_server(*args, DefaultTokioExecutor::default())
-                .await
-                .unwrap_or_else(|err| {
-                    panic!("Cannot start wstunnel server: {err:?}");
-                });
-        }
-    }
+        None => tokio::runtime::Builder::new_multi_thread(),
+    };
+    let rt = builder.enable_all().build()?;
 
-    Ok(())
+    rt.block_on(async move {
+        // Start system CA reloader
+        SystemCaReloader::start(None);
+
+        match args.commands {
+            Commands::Client(args) => {
+                run_client(*args, DefaultTokioExecutor::default())
+                    .await
+                    .unwrap_or_else(|err| {
+                        panic!("Cannot start wstunnel client: {err:?}");
+                    });
+            }
+            Commands::Server(args) => {
+                run_server(*args, DefaultTokioExecutor::default())
+                    .await
+                    .unwrap_or_else(|err| {
+                        panic!("Cannot start wstunnel server: {err:?}");
+                    });
+            }
+        }
+
+        Ok(())
+    })
 }


### PR DESCRIPTION
## Description
Previously, the `--nb-worker-threads` CLI argument was parsed by clap but was not used to configure the Tokio runtime (as `#[tokio::main]` initialized the default multi-threaded runtime before `main` parsed CLI args).

This PR initializes the Tokio runtime manually inside `main()` based on `--nb-worker-threads`:
- `nb_worker_threads == Some(1)`: Initializes a single-threaded runtime (`tokio::runtime::Builder::new_current_thread()`).
- `nb_worker_threads == Some(n)`: Initializes a multi-threaded runtime with `n` worker threads (`tokio::runtime::Builder::new_multi_thread().worker_threads(n)`).
- `nb_worker_threads == None`: Initializes default multi-threaded runtime.

## Changes
- [wstunnel-cli/src/main.rs](file:///d:/githome/spritetong/wstunnel/wstunnel-cli/src/main.rs): Replaced `#[tokio::main]` attribute macro with manual `tokio::runtime::Builder` configuration and execution via `rt.block_on(...)`.
- [README.md](file:///d:/githome/spritetong/wstunnel/README.md) & [wstunnel-cli/src/main.rs](file:///d:/githome/spritetong/wstunnel/wstunnel-cli/src/main.rs): Removed outdated warning stating that the flag does nothing.

## Verification
- `cargo check`: Passed
- `cargo fmt --check`: Passed
- `cargo test -p wstunnel-cli`: Passed
