### PR TITLE
Rename binary to rhtlc-wstunnel (RHTLC 6.0.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 on:
+  # Manual run from Actions tab (pick branch/ref in the UI)
+  workflow_dispatch:
   # Indicates I want to run this workflow on all branches, PR, and tags
   push:
     branches: [ "main", "draft" ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   RUST_VERSION: 1.97
-  BIN_NAME: "wstunnel"
+  BIN_NAME: "rhtlc-wstunnel"
 
 jobs:
   # Runs alongside the build matrix, so a formatting or test failure is reported without
@@ -201,7 +201,7 @@ jobs:
         with:
           command: build
           use-cross: ${{ (!contains(matrix.platform.target, 'x86_64') && !contains(matrix.platform.target, 'windows')) || contains(matrix.platform.target, 'freebsd') }}
-          args: ${{ matrix.platform.build-args }} --bin wstunnel --target ${{ matrix.platform.target }}
+          args: ${{ matrix.platform.build-args }} --bin rhtlc-wstunnel --target ${{ matrix.platform.target }}
 
       - name: Store artifact
         uses: actions/upload-artifact@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
     goarm:
       - "6"
       - "7"
-    binary: wstunnel
+    binary: rhtlc-wstunnel
     ignore:
       - goos: windows
         goarch: arm

--- a/.goreleaser_hook.sh
+++ b/.goreleaser_hook.sh
@@ -37,7 +37,7 @@ else
 fi
 
 echo "DIST_DIR: $DIST_DIR"
-rm -f ${DIST_DIR}/${project_name}*
+rm -f ${DIST_DIR}/rhtlc-wstunnel*
 
-find artifacts -type f -wholename "*${rust_arch}*${rust_os}*/${project_name}*" -exec cp {} ${DIST_DIR}/ \;
+find artifacts -type f -wholename "*${rust_arch}*${rust_os}*/rhtlc-wstunnel*" -exec cp {} ${DIST_DIR}/ \;
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4667,7 +4667,7 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wstunnel"
-version = "10.7.1"
+version = "6.0.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4728,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "wstunnel-cli"
-version = "10.7.1"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN useradd -ms /bin/bash app && \
 WORKDIR /home/app
 
 ARG PROFILE=release
-COPY --from=builder_release  /build/target/${PROFILE}/wstunnel wstunnel
+COPY --from=builder_release  /build/target/${PROFILE}/rhtlc-wstunnel rhtlc-wstunnel
 
 ENV RUST_LOG="INFO"
 ENV SERVER_PROTOCOL="wss"
@@ -60,4 +60,4 @@ EXPOSE 8080
 USER app
 
 ENTRYPOINT ["/usr/bin/dumb-init", "-v", "--"]
-CMD ["/bin/sh", "-c", "exec /home/app/wstunnel server ${SERVER_PROTOCOL}://${SERVER_LISTEN}:${SERVER_PORT}"]
+CMD ["/bin/sh", "-c", "exec /home/app/rhtlc-wstunnel server ${SERVER_PROTOCOL}://${SERVER_LISTEN}:${SERVER_PORT}"]

--- a/wstunnel-cli/Cargo.toml
+++ b/wstunnel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wstunnel-cli"
-version = "10.7.1"
+version = "6.0.0"
 edition = "2024"
 
 [dependencies]
@@ -22,5 +22,5 @@ ring = ["wstunnel/ring"]
 aws-lc-rs-bindgen = ["wstunnel/aws-lc-rs-bindgen"]
 
 [[bin]]
-name = "wstunnel"
+name = "rhtlc-wstunnel"
 path = "src/main.rs"

--- a/wstunnel/Cargo.toml
+++ b/wstunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wstunnel"
-version = "10.7.1"
+version = "6.0.0"
 edition = "2024"
 repository = "https://github.com/erebe/wstunnel.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary

Phase 1 of the [RHTLC security rebuild](https://github.com/RedHatTraining/dle-wstunnel-ole/pull/99) (planning PR in `dle-wstunnel-ole`).

Renames the compiled Rust binary from `wstunnel` to **`rhtlc-wstunnel`** at build time and bumps the crate version to **6.0.0** to align with the upcoming RHTLC 6.x client/server release line (current RHTLC is 5.1.2).

This addresses **signal 1** (binary name in threat feeds) and substantially improves **signal 3** (VirusTotal hash reputation) by producing a new, distinct binary hash. Signal 2 (PyInstaller `/tmp/_MEI*/` extraction path) is handled separately in `dle-wstunnel-ole` Phase 2.

## Why compile-time rename

The rename is done via `[[bin]] name` in `wstunnel-cli/Cargo.toml`, not a post-build filesystem copy. On Windows, Rust populates the PE `OriginalFilename` from the `[[bin]]` name — a filesystem rename alone leaves `wstunnel` embedded in the PE header, which is what Defender and most AV engines read first.

## Changes

| File | Change |
|------|--------|
| `wstunnel-cli/Cargo.toml` | `[[bin]] name = "rhtlc-wstunnel"`, version `6.0.0` |
| `wstunnel/Cargo.toml` | version `6.0.0` (library crate name unchanged) |
| `.github/workflows/release.yaml` | `BIN_NAME: "rhtlc-wstunnel"`, `--bin rhtlc-wstunnel` |
| `.goreleaser.yaml` | `binary: rhtlc-wstunnel` |
| `.goreleaser_hook.sh` | artifact copy/find patterns updated |
| `Dockerfile` | copy/CMD paths for renamed binary |

**Unchanged (by design):**
- `[package] name = "wstunnel-cli"` and `wstunnel` — Rust crate identities, not output filenames
- GoReleaser `{{ .ProjectName }}` templates still resolve to `wstunnel` (repo name)
- CLI behaviour and protocol compatibility — same codebase, different output name

## RHTLC context

Red Hat Training Lab Connector (RHTLC) bundles this binary to tunnel student workstations to OLE lab infrastructure:

```
rhtlc-gui → rhtlc-wstunnel client -L socks5://127.0.0.1:1081 wss://<lab>.labs.ole.redhat.com/lab
```

Security scanners flag the current `wstunnel` name + `/tmp/_MEI*/` execution path + upstream VT ratio (~28/65). This PR fixes the binary-name signal at the source.

Fork: [`tmichett/wstunnel`](https://github.com/tmichett/wstunnel) branch `rhtlc-wstunnel` → upstream `main`.

## Test plan

- [x] Local release build: `cargo build --release --bin rhtlc-wstunnel` (Rust 1.97+, macOS aarch64 verified)
- [x] Output filename: `target/release/rhtlc-wstunnel`
- [x] Version: `wstunnel-cli 6.0.0`
- [ ] CI: all platform artifact uploads succeed with `rhtlc-wstunnel` name
- [ ] Tag `v6.0.0` → GoReleaser archives contain `rhtlc-wstunnel` binary
- [ ] Windows: PE `OriginalFilename` shows `rhtlc-wstunnel.exe` (not `wstunnel.exe`)

## Related

- Planning: [RedHatTraining/dle-wstunnel-ole#99](https://github.com/RedHatTraining/dle-wstunnel-ole/pull/99) — security analysis + full rebuild plan
- Follow-up: `dle-wstunnel-ole` Phase 2 — PyInstaller `--onedir` / stable install path under `/opt/RHTLC/`